### PR TITLE
docs: adjudicate ADR-001 spec decisions (#2) [ADR-001]

### DIFF
--- a/docs/decisions/0001-open-specification-decisions.md
+++ b/docs/decisions/0001-open-specification-decisions.md
@@ -1,77 +1,69 @@
 # ADR-001: Open decisions and change candidates against specification 0.2.0
 
-Status: Proposed — each item needs an explicit adjudication before or during
-the implementation slice it affects. Accepted changes to the specification
-must land through the change record in
+Status: Adjudicated 2026-08-15 (issue #2). Dispositions recorded per item.
+Accepted specification changes landed through the change record in
 [`../specification-baseline.md`](../specification-baseline.md).
 
-## A. Editorial corrections (low risk, need a recorded spec amendment)
+## A. Editorial corrections
 
-1. **§27.7 mojibake** — the text reads "according to Â§14.5"; the `Â` is a
-   UTF-8/CP1252 encoding artifact and should read "§14.5".
-2. **§2.2 K-DLC reference** — links to
-   `./knowledge-development-lifecycle-specification.md`, which does not exist
-   in this repository. Replace with the canonical cross-repository URL
-   (https://github.com/aithinkers/knowledge-dlc).
-3. **§9 architecture diagram** — the `RAID+D` row has inconsistent box
-   alignment (cosmetic).
-4. **§2.4 migration steps** — the 0.1→0.2 migration procedure is normative,
-   but no 0.1 project exists. Mark the migration clause informative-until-1.0
-   or keep it as a conformance fixture requirement only (§44.1 item 16 vs.
-   §46 item 14 both reference a "migration fixture" — decide which governs).
+1. **§27.7 mojibake** — **Rejected (moot).** The committed specification is
+   clean UTF-8 ("§14.5"); the artifact existed only in an external pasted
+   copy, not in the baseline bytes.
+2. **§2.2 K-DLC reference** — **Accepted.** The relative link to
+   `./knowledge-development-lifecycle-specification.md` was replaced with the
+   canonical cross-repository URL.
+3. **§9 architecture diagram alignment** — **Deferred.** Cosmetic; batch with
+   a future editorial revision rather than churn the baseline hash alone.
+4. **§2.4 migration steps** — **Accepted.** A clarifying paragraph marks the
+   0.1→0.2 migration procedure informative until an implementation claims
+   such a migration, while retaining it as a §44.1 conformance fixture
+   requirement.
 
-## B. Reference-distribution decisions (block implementation slices)
+## B. Reference-distribution decisions
 
-5. **UUIDv7 source** — Node's `crypto.randomUUID()` emits v4. Decide: vendor a
-   small audited UUIDv7 implementation (recommended — deterministic, no new
-   dependency) vs. the `uuid` npm package. Affects §12.1 and every schema.
-6. **rdlc-jcs-v1 layering** — RFC 8785 serialization can reuse the
-   `canonicalize` package already trusted in K-DLC, but the profile's
-   schema-driven set-sorting, NFC normalization, decimal-as-string, and
-   absence-vs-null rules must be an authored layer above it. Decide the
-   schema annotation format for "set-like array" and "governed field"
-   (proposal: `x-rdlc-set-keys` / `x-rdlc-governed` JSON Schema extensions).
-7. **Lease authority for 0.1** — §11.1 example names
-   `git-ref-compare-and-swap` over `refs/rdlc/leases`; §35.9 requires atomic
-   CAS visible to all writers. Git ref updates via the GitHub API are
-   CAS-capable; plain `git push` is not a safe CAS under races on some
-   transports. Decide the reference lease authority: GitHub API ref CAS
-   (recommended), provider-conditional-create, or defer multi-writer leases
-   behind a single-writer default for 0.1.
-8. **Intake stack** — §16.2.3's informative stack is Python-centric (PyMuPDF,
-   python-docx, openpyxl). This repository's tooling is Node. Decide: reuse
-   the K-DLC Node extraction stack (pdfjs-dist, fflate, saxes, csv-parse,
-   gifuct-js) and amend §16.2.3, or introduce a Python toolchain. Recommend
-   Node reuse; VSDX/MSG/OCR support becomes "conditional" until a sandboxed
-   adapter exists.
-9. **Jira test surface** — §46 requires a *synthetic* Jira Cloud
-   company-managed project for the DoD scenario. Decide: recorded sanitized
-   fixtures as the CI contract plus an optional live suite against a
-   dedicated Atlassian sandbox (who owns the tenant and credentials; secrets
-   never in-repo per §11.1). CI must pass with fixtures alone.
-10. **Identity verification in a CLI harness** — §27.2 "authenticated
-    self-binding" needs a concrete 0.1 mechanism. Proposal: bind via an
-    authenticated Jira `myself` API call over the user-supplied token,
-    recording the immutable accountId; full OAuth device flow deferred.
-11. **Scale benchmark environment** — §7.10 requires a published benchmark
-    with declared hardware. Decide the reference environment (proposal: the
-    GitHub-hosted `ubuntu-latest` runner class, documented per run) and when
-    the 5,000-artifact fixture generator lands (needed by §44.1 item 20).
-12. **Trusted time / regulated profile** — out of 0.1 scope (§45.3); confirm
-    no `Governed-Regulated` schema stubs are published early enough to be
-    mistaken for supported capability.
+5. **UUIDv7 source** — **Accepted: vendor a small audited UUIDv7
+   implementation** (deterministic, no new dependency) instead of the `uuid`
+   npm package. Lands with FEAT-004 (#5).
+6. **rdlc-jcs-v1 layering** — **Accepted: reuse the `canonicalize` package**
+   for RFC 8785 serialization, with an authored profile layer implementing
+   schema-driven set sorting, NFC normalization, decimal/large-integer
+   strings, and absence-vs-null rules via `x-rdlc-set-keys` and
+   `x-rdlc-governed` JSON Schema extension keywords. Lands with FEAT-003 (#4).
+7. **Lease authority for 0.1** — **Accepted: GitHub API ref compare-and-swap**
+   over `refs/rdlc/leases/*` as the reference lease authority (atomic CAS
+   visible to all writers); plain `git push` is not treated as a safe CAS.
+   Lands with FEAT-004/FEAT-008 (#5, #9).
+8. **Intake stack** — **Accepted: Node.js stack reusing K-DLC's trusted
+   parsers** (pdfjs-dist, fflate, saxes, csv-parse, gifuct-js and peers);
+   §16.2.3 amended to state the named tools are exemplary. VSDX, MSG, and OCR
+   support are conditional until a sandboxed adapter exists. Lands with
+   FEAT-007 (#8).
+9. **Jira test surface** — **Accepted: recorded sanitized fixtures are the CI
+   contract.** Live-suite wiring against a dedicated Atlassian sandbox is
+   **deferred** until a tenant exists (owner decision 2026-08-15); credentials
+   would enter only via GitHub secrets, never the repository. Lands with
+   FEAT-010 (#11).
+10. **Identity self-binding in a CLI harness** — **Accepted:** bind via an
+    authenticated Jira `myself` API call over the user-supplied credential,
+    recording the immutable `accountId`; full OAuth device flow deferred.
+    Lands with FEAT-009 (#10).
+11. **Scale benchmark environment** — **Accepted: GitHub-hosted
+    `ubuntu-latest` runner class**, with hardware/runtime details captured per
+    run in the published benchmark record. Lands with REL-001 (#13).
+12. **Regulated profile stubs** — **Accepted:** no `Governed-Regulated`
+    schemas or stubs are published in 0.1; the profile first appears with its
+    conformance tests (§45.3).
 
-## C. Repository-process decisions (this repo's governance, not the spec)
+## C. Repository-process decisions
 
-13. **Deferred K-DLC governance machinery** — release-matrix, supply-chain
-    verification, and statistical-evidence workflows are not ported in the
-    bootstrap. They become REL-scoped issues once there is a distribution to
-    release. Until then `Full`-style claims are impossible by construction.
-14. **Standing self-review fixture (§44.3)** — requires the frozen 0.1 spec
-    and its critical-review findings. Those artifacts must be imported (from
-    the authoring workspace) or the clause amended to start the fixture at
-    0.2. Decide before REL work begins.
-15. **Spec §46/§44 semantic evaluation** — semantic review quality claims need
-    versioned datasets; adopt K-DLC's recorded-evaluation pattern when the
-    first semantic reviewer ships (release 0.2 per §45.2 is when this becomes
-    binding — confirm scope).
+13. **Deferred K-DLC governance machinery** — **Accepted:** release-matrix,
+    supply-chain verification, and statistical-evidence workflows are not
+    ported at bootstrap; they arrive as REL-scoped issues once a distribution
+    exists. `Full`-style claims remain impossible by construction.
+14. **Standing self-review fixture (§44.3)** — **Deferred pending import:**
+    the frozen 0.1 specification and its critical-review findings live in the
+    authoring workspace; import them under `fixtures/self-review/` before
+    REL-001 verification, or amend the clause to start the fixture at 0.2.
+15. **Semantic evaluation scope** — **Accepted:** adopt K-DLC's
+    recorded-evaluation pattern when the first semantic reviewer ships;
+    binding no earlier than reference release 0.2 (§45.2).

--- a/docs/requirements-development-lifecycle-specification.md
+++ b/docs/requirements-development-lifecycle-specification.md
@@ -98,7 +98,7 @@ dependencies of R-DLC:
 - [AWS AI-DLC session management](https://awslabs.github.io/aidlc-workflows/guide/11-session-management/)
 - [AWS AI-DLC Kiro IDE harness](https://awslabs.github.io/aidlc-workflows/guide/harnesses/kiro-ide/)
 - [gstack](https://github.com/garrytan/gstack)
-- [K-DLC specification](./knowledge-development-lifecycle-specification.md)
+- [K-DLC specification](https://github.com/aithinkers/knowledge-dlc/blob/main/docs/knowledge-development-lifecycle-specification.md)
 
 R-DLC adopts the useful concepts of adaptive stages, explicit artifacts,
 human gates, persistent workflow state, recovery, role-based review, and small
@@ -174,6 +174,10 @@ project migrating to 0.2 SHALL:
    after successful migration validation. Migration SHALL be idempotent and
    produce a report mapping every old identity, status, and approval record to
    its new representation.
+
+No conforming 0.1 project is known to exist. This migration procedure is
+retained as a conformance fixture requirement (§44.1) and is otherwise
+informative until an implementation claims a 0.1-to-0.2 migration.
 
 ## 3. Problem Statement
 
@@ -1310,6 +1314,11 @@ version, extraction profile, or normalization schema changes. A persistent
 SQLite index is out of scope for reference distribution release 0.1.
 
 #### 16.2.3 Reference extraction stack (informative)
+
+The tools named below are exemplary rather than required. The reference
+distribution realizes the same staged adapter contract and coverage-reporting
+obligations with a Node.js-based extraction stack; any stack satisfying
+§16.2.1 and §16.2.2 is acceptable.
 
 The recommended implementation uses narrow, structure-aware parsers first and
 a sandboxed broad-format fallback:

--- a/docs/specification-baseline.md
+++ b/docs/specification-baseline.md
@@ -2,17 +2,19 @@
 
 The repository baseline is
 [`requirements-development-lifecycle-specification.md`](requirements-development-lifecycle-specification.md),
-imported byte-for-byte from the implementation draft supplied on 2026-08-15.
+imported byte-for-byte from the implementation draft supplied on 2026-08-15
+and since amended only through the recorded change process below.
 
 - Framework: R-DLC
 - Specification version: 0.2.0
 - Status: Draft for implementation
-- SHA-256: `8caa9d3039e5ff98c2e0b283261639617913a3a3d577f622a69c61dbe539a8a5`
+- SHA-256: `173c3ad8fc4a81ad7e5883aa20a3874a451ccc22ec4c93244860d1fcbd68f0ba`
 
 ## Change record
 
 | Date | Issue | Change | Prior SHA-256 |
 |---|---|---|---|
+| 2026-08-15 | #2 (ADR-001) | Replaced the §2.2 relative K-DLC link with the canonical cross-repository URL; marked the §2.4 migration procedure informative until claimed; noted in §16.2.3 that the named extraction tools are exemplary and the reference distribution uses a Node.js stack. Dispositions in `decisions/0001-open-specification-decisions.md`. | `8caa9d3039e5ff98c2e0b283261639617913a3a3d577f622a69c61dbe539a8a5` |
 
 Changing this file requires a requirement issue, compatibility analysis,
 migration decision, updated traceability, and review. Known editorial and

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -11,8 +11,12 @@
       "id": "FEAT-001",
       "title": "Governance and repository bootstrap",
       "issue": 1,
-      "specification_sections": ["§2.3", "§7.2", "§44.1"],
-      "status": "in-progress",
+      "specification_sections": [
+        "§2.3",
+        "§7.2",
+        "§44.1"
+      ],
+      "status": "verified",
       "evidence": {
         "implementation": [
           ".github/workflows/governance.yml",
@@ -22,17 +26,31 @@
           "development/agent-workflow.json",
           "docs/specification-baseline.md"
         ],
-        "tests": ["tests/governance/governance.test.mjs"]
+        "tests": [
+          "tests/governance/governance.test.mjs"
+        ]
       }
     },
     {
       "id": "ADR-001",
       "title": "Adjudicate open specification decisions for 0.2.0",
       "issue": 2,
-      "specification_sections": ["§2.3", "§2.4", "§7.10", "§12.5", "§16.2.3", "§27.2", "§35.9"],
-      "status": "in-progress",
+      "specification_sections": [
+        "§2.3",
+        "§2.4",
+        "§7.10",
+        "§12.5",
+        "§16.2.3",
+        "§27.2",
+        "§35.9"
+      ],
+      "status": "implemented",
       "evidence": {
-        "implementation": ["docs/decisions/0001-open-specification-decisions.md"],
+        "implementation": [
+          "docs/decisions/0001-open-specification-decisions.md",
+          "docs/specification-baseline.md",
+          "docs/requirements-development-lifecycle-specification.md"
+        ],
         "tests": []
       }
     },
@@ -40,89 +58,170 @@
       "id": "FEAT-002",
       "title": "Portable v0.2 schemas and artifact envelope",
       "issue": 3,
-      "specification_sections": ["§11", "§12.1", "§12.2", "§12.3", "§12.4", "§13", "§16.1"],
+      "specification_sections": [
+        "§11",
+        "§12.1",
+        "§12.2",
+        "§12.3",
+        "§12.4",
+        "§13",
+        "§16.1"
+      ],
       "status": "planned",
-      "evidence": {"implementation": [], "tests": []}
+      "evidence": {
+        "implementation": [],
+        "tests": []
+      }
     },
     {
       "id": "FEAT-003",
       "title": "rdlc-jcs-v1 canonical serialization and hash profiles",
       "issue": 4,
-      "specification_sections": ["§12.5", "§12.6"],
+      "specification_sections": [
+        "§12.5",
+        "§12.6"
+      ],
       "status": "planned",
-      "evidence": {"implementation": [], "tests": []}
+      "evidence": {
+        "implementation": [],
+        "tests": []
+      }
     },
     {
       "id": "FEAT-004",
       "title": "UUIDv7 identity and display-alias allocation",
       "issue": 5,
-      "specification_sections": ["§12.1", "§12.2", "§35.9"],
+      "specification_sections": [
+        "§12.1",
+        "§12.2",
+        "§35.9"
+      ],
       "status": "planned",
-      "evidence": {"implementation": [], "tests": []}
+      "evidence": {
+        "implementation": [],
+        "tests": []
+      }
     },
     {
       "id": "FEAT-005",
       "title": "Lifecycle state machines and materiality policy",
       "issue": 6,
-      "specification_sections": ["§14", "§27.7"],
+      "specification_sections": [
+        "§14",
+        "§27.7"
+      ],
       "status": "planned",
-      "evidence": {"implementation": [], "tests": []}
+      "evidence": {
+        "implementation": [],
+        "tests": []
+      }
     },
     {
       "id": "FEAT-006",
       "title": "Capture, triage, promotion gate, and trace coverage",
       "issue": 7,
-      "specification_sections": ["§14.4", "§35.3", "§35.4", "§13"],
+      "specification_sections": [
+        "§14.4",
+        "§35.3",
+        "§35.4",
+        "§13"
+      ],
       "status": "planned",
-      "evidence": {"implementation": [], "tests": []}
+      "evidence": {
+        "implementation": [],
+        "tests": []
+      }
     },
     {
       "id": "FEAT-007",
       "title": "Bounded scope-document intake matrix",
       "issue": 8,
-      "specification_sections": ["§16.2", "§16.2.1", "§16.2.2", "§16.2.3"],
+      "specification_sections": [
+        "§16.2",
+        "§16.2.1",
+        "§16.2.2",
+        "§16.2.3"
+      ],
       "status": "planned",
-      "evidence": {"implementation": [], "tests": []}
+      "evidence": {
+        "implementation": [],
+        "tests": []
+      }
     },
     {
       "id": "FEAT-008",
       "title": "Multi-BA collaboration, claims, leases, and collisions",
       "issue": 9,
-      "specification_sections": ["§35"],
+      "specification_sections": [
+        "§35"
+      ],
       "status": "planned",
-      "evidence": {"implementation": [], "tests": []}
+      "evidence": {
+        "implementation": [],
+        "tests": []
+      }
     },
     {
       "id": "FEAT-009",
       "title": "Identity registry, approvals, baselines, and redaction",
       "issue": 10,
-      "specification_sections": ["§27", "§41.1"],
+      "specification_sections": [
+        "§27",
+        "§41.1"
+      ],
       "status": "planned",
-      "evidence": {"implementation": [], "tests": []}
+      "evidence": {
+        "implementation": [],
+        "tests": []
+      }
     },
     {
       "id": "FEAT-010",
       "title": "Jira Cloud company-managed connector",
       "issue": 11,
-      "specification_sections": ["§29", "§30", "§33", "§44.4"],
+      "specification_sections": [
+        "§29",
+        "§30",
+        "§33",
+        "§44.4"
+      ],
       "status": "planned",
-      "evidence": {"implementation": [], "tests": []}
+      "evidence": {
+        "implementation": [],
+        "tests": []
+      }
     },
     {
       "id": "FEAT-011",
       "title": "Claude Code harness, persistent state, and resume",
       "issue": 12,
-      "specification_sections": ["§34", "§36", "§37", "§15"],
+      "specification_sections": [
+        "§34",
+        "§36",
+        "§37",
+        "§15"
+      ],
       "status": "planned",
-      "evidence": {"implementation": [], "tests": []}
+      "evidence": {
+        "implementation": [],
+        "tests": []
+      }
     },
     {
       "id": "REL-001",
       "title": "Release 0.1 conformance suite and definition of done",
       "issue": 13,
-      "specification_sections": ["§44", "§45.1", "§46", "§7.10"],
+      "specification_sections": [
+        "§44",
+        "§45.1",
+        "§46",
+        "§7.10"
+      ],
       "status": "planned",
-      "evidence": {"implementation": [], "tests": []}
+      "evidence": {
+        "implementation": [],
+        "tests": []
+      }
     }
   ]
 }


### PR DESCRIPTION
## Outcome

Adjudicates all 15 ADR-001 items with recorded dispositions and lands the three accepted specification amendments (§2.2 cross-repository K-DLC link, §2.4 migration-clause informative note, §16.2.3 exemplary-tools note) through the baseline change record. Also flips FEAT-001 to verified now that the bootstrap merged with passing checks.

Closes #2

## Traceability

- Requirement IDs: ADR-001
- Specification sections: §2.2, §2.4, §16.2.3 (amended); §7.10, §12.5, §27.2, §35.9 (dispositions)
- Conformance modules affected: Development-only
- Traceability index updated: yes — ADR-001 implemented with evidence; FEAT-001 verified

## Gate evidence

- [x] Feature/requirement definition is complete and linked.
- [x] Implementation plan received the required review (owner adopted recommended dispositions 2026-08-15).
- [x] Development stayed within issue scope.
- [x] Deterministic tests cover acceptance and failure criteria (baseline-hash test rebinds to the amended spec).
- [x] Final review considered correctness, security, and traceability.

Commands and results:

```text
npm test
> check:governance — Governance verified: 13 traceable requirements and 5 development gates.
> test:governance — 8 pass, 0 fail (includes specification-baseline SHA-256 rebind to 173c3ad8…68f0ba)
```

## Security, privacy, rights, and retention

Documentation-only change; no workflow, script, or protected harness file modified. Decision 9 records that Jira live-suite credentials, if ever added, enter only via GitHub secrets.

## Compatibility, migration, and rollback

Spec amendments are clarifying, not semantic; prior SHA-256 retained in the change record. Rollback = revert commit and restore prior baseline row.

## Release and documentation

Dispositions unblock FEAT-002..FEAT-011 implementation choices (UUIDv7 vendoring, rdlc-jcs-v1 layering over canonicalize, GitHub ref CAS leases, Node intake stack, fixture-based Jira CI).
