### PR TITLE
feat: portable v0.2 schemas and artifact envelope (#3) [FEAT-002]

### DIFF
--- a/core/schemas/v0.2/artifact.schema.json
+++ b/core/schemas/v0.2/artifact.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rdlc.dev/schemas/v0.2/artifact.schema.json",
+  "title": "R-DLC governed artifact envelope (spec §12.3)",
+  "type": "object",
+  "required": [
+    "schema_version", "id", "project", "type", "title",
+    "governance_state", "version", "origin", "created_at", "updated_at"
+  ],
+  "properties": {
+    "schema_version": { "const": "rdlc.artifact/v0.2" },
+    "id": { "$ref": "common.schema.json#/$defs/uuidUrn" },
+    "display_id": { "$ref": "common.schema.json#/$defs/displayAlias" },
+    "project": { "type": "string", "minLength": 1 },
+    "type": { "type": "string", "minLength": 1 },
+    "title": { "type": "string", "minLength": 1 },
+    "governance_state": { "$ref": "common.schema.json#/$defs/governanceState" },
+    "synchronization_state": { "$ref": "common.schema.json#/$defs/synchronizationState" },
+    "verification_progress": { "$ref": "common.schema.json#/$defs/verificationProgress" },
+    "verification_outcome": { "$ref": "common.schema.json#/$defs/verificationOutcome" },
+    "version": { "type": "integer", "minimum": 1 },
+    "origin": {
+      "type": "object",
+      "required": ["kind"],
+      "properties": {
+        "kind": {
+          "enum": ["user-capture", "import", "ai-candidate", "deterministic-derivation", "migration"]
+        },
+        "actor": { "$ref": "common.schema.json#/$defs/actorReference" },
+        "captured_at": { "$ref": "common.schema.json#/$defs/rfc3339Utc" }
+      },
+      "additionalProperties": false
+    },
+    "statement": { "type": "string", "minLength": 1 },
+    "rationale": { "type": "string" },
+    "owner": { "$ref": "common.schema.json#/$defs/actorReference" },
+    "sources": {
+      "type": "array",
+      "items": { "$ref": "common.schema.json#/$defs/sourceReference" }
+    },
+    "relationships": {
+      "type": "array",
+      "items": { "$ref": "common.schema.json#/$defs/relationship" }
+    },
+    "external_refs": { "type": "array", "items": { "type": "object" } },
+    "content_hash": { "$ref": "common.schema.json#/$defs/sha256" },
+    "created_at": { "$ref": "common.schema.json#/$defs/rfc3339Utc" },
+    "updated_at": { "$ref": "common.schema.json#/$defs/rfc3339Utc" }
+  },
+  "additionalProperties": true,
+  "x-rdlc-governed": [
+    "type", "title", "statement", "rationale", "owner",
+    "sources", "relationships"
+  ],
+  "x-rdlc-set-keys": { "relationships": ["type", "target"], "sources": null }
+}

--- a/core/schemas/v0.2/changeset.schema.json
+++ b/core/schemas/v0.2/changeset.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rdlc.dev/schemas/v0.2/changeset.schema.json",
+  "title": "R-DLC connector changeset (spec §33.1)",
+  "type": "object",
+  "required": ["schema_version", "id", "connection", "created_by", "created_at", "mode", "operations", "approval"],
+  "properties": {
+    "schema_version": { "const": "rdlc.changeset/v0.2" },
+    "id": { "$ref": "common.schema.json#/$defs/uuidUrn" },
+    "display_id": { "$ref": "common.schema.json#/$defs/displayAlias" },
+    "connection": { "type": "string", "minLength": 1 },
+    "created_by": { "$ref": "common.schema.json#/$defs/uuidUrn" },
+    "created_at": { "$ref": "common.schema.json#/$defs/rfc3339Utc" },
+    "mode": { "enum": ["read-only", "propose", "approve-each-batch", "approved-automation"] },
+    "operations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["operation_id", "action"],
+        "properties": {
+          "operation_id": { "type": "string", "pattern": "^op-[0-9]{3,}$" },
+          "action": {
+            "enum": ["create", "update", "link", "unlink", "comment", "transition", "set-fields", "attach"]
+          },
+          "artifact": { "$ref": "common.schema.json#/$defs/uuidUrn" },
+          "source": { "$ref": "common.schema.json#/$defs/uuidUrn" },
+          "target": {},
+          "relation": { "type": "string", "minLength": 1 },
+          "idempotency_key": { "type": "string", "pattern": "^rdlc:[0-9a-f-]{36}$" },
+          "preconditions": { "type": "object" },
+          "fields": { "type": "object" }
+        },
+        "additionalProperties": false,
+        "allOf": [
+          {
+            "if": { "properties": { "action": { "const": "create" } } },
+            "then": { "required": ["artifact", "target", "idempotency_key"] }
+          },
+          {
+            "if": { "properties": { "action": { "const": "link" } } },
+            "then": { "required": ["source", "relation", "target"] }
+          }
+        ]
+      }
+    },
+    "approval": {
+      "type": "object",
+      "required": ["required", "status"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "status": { "enum": ["pending", "approved", "rejected", "not-required"] },
+        "package_hash": { "$ref": "common.schema.json#/$defs/sha256" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/core/schemas/v0.2/changeset.schema.json
+++ b/core/schemas/v0.2/changeset.schema.json
@@ -39,7 +39,14 @@
           },
           {
             "if": { "properties": { "action": { "const": "link" } } },
-            "then": { "required": ["source", "relation", "target"] }
+            "then": {
+              "required": ["source", "relation", "target"],
+              "properties": { "target": { "$ref": "common.schema.json#/$defs/uuidUrn" } }
+            }
+          },
+          {
+            "if": { "properties": { "action": { "const": "create" } } },
+            "then": { "properties": { "target": { "type": "object" } } }
           }
         ]
       }

--- a/core/schemas/v0.2/common.schema.json
+++ b/core/schemas/v0.2/common.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rdlc.dev/schemas/v0.2/common.schema.json",
+  "title": "R-DLC common definitions (spec §12)",
+  "$defs": {
+    "uuidUrn": {
+      "type": "string",
+      "pattern": "^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+      "description": "Canonical UUIDv7 URN identity (§12.1)."
+    },
+    "displayAlias": {
+      "type": "string",
+      "pattern": "^[A-Z][A-Z0-9]*-[A-Za-z0-9-]+$",
+      "description": "Human-readable display alias such as REQ-104 (§12.2). Never a canonical identity."
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "description": "Lowercase SHA-256 hash encoding (§12.5)."
+    },
+    "rfc3339Utc": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z$",
+      "description": "RFC 3339 instant normalized to UTC with Z suffix (§12.6)."
+    },
+    "governanceState": {
+      "enum": [
+        "captured", "triaged", "working", "draft", "reviewed",
+        "ready-for-approval", "awaiting-approval", "approved", "baselined",
+        "collision-review", "needs-clarification", "deferred", "rejected",
+        "superseded", "retired", "withdrawn"
+      ],
+      "description": "Governance lifecycle states and conditions (§14.1.1)."
+    },
+    "synchronizationState": {
+      "enum": ["not-synchronized", "planned", "applying", "synchronized", "drifted", "failed", "uncertain"],
+      "description": "Synchronization states (§14.1.1)."
+    },
+    "verificationProgress": {
+      "enum": ["not-designed", "designed", "reviewed", "implemented", "executed"],
+      "description": "Verification progress states (§14.1)."
+    },
+    "verificationOutcome": {
+      "enum": ["none", "passed", "failed", "blocked", "inconclusive", "waived"],
+      "description": "Verification outcomes (§14.1)."
+    },
+    "relationshipType": {
+      "enum": [
+        "derives-from", "decomposes", "satisfies", "implements", "validated-by",
+        "tested-by", "evidenced-by", "affects", "owned-by", "depends-on",
+        "blocks", "conflicts-with", "overlaps", "duplicates", "supersedes",
+        "mitigates", "resolves", "approves"
+      ],
+      "description": "Core relationship types (§13)."
+    },
+    "relationship": {
+      "type": "object",
+      "required": ["type", "target"],
+      "properties": {
+        "type": { "$ref": "#/$defs/relationshipType" },
+        "target": { "$ref": "#/$defs/uuidUrn" },
+        "status": { "enum": ["candidate", "accepted", "rejected", "superseded"] },
+        "origin": { "type": "string", "minLength": 1 },
+        "rationale": { "type": "string", "minLength": 1 },
+        "creator": { "$ref": "#/$defs/uuidUrn" },
+        "created_at": { "$ref": "#/$defs/rfc3339Utc" },
+        "confidence": { "enum": ["low", "medium", "high"] }
+      },
+      "additionalProperties": false,
+      "description": "Typed relationship record (§13). Targets must be canonical UUID URNs, never display aliases (§12.2)."
+    },
+    "sourceReference": {
+      "type": "string",
+      "pattern": "^(kb|external|req)://\\S+$",
+      "description": "Stable evidence reference such as kb://… or external://… (§12.3, §16)."
+    },
+    "actorReference": {
+      "anyOf": [
+        { "$ref": "#/$defs/uuidUrn" },
+        { "type": "string", "pattern": "^role:[a-z][a-z0-9-]*$" }
+      ],
+      "description": "Canonical principal URN or role reference."
+    }
+  }
+}

--- a/core/schemas/v0.2/finding.schema.json
+++ b/core/schemas/v0.2/finding.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rdlc.dev/schemas/v0.2/finding.schema.json",
+  "title": "R-DLC review finding (spec §24.3)",
+  "type": "object",
+  "required": ["schema_version", "id", "rule", "severity", "artifact", "message", "status"],
+  "properties": {
+    "schema_version": { "const": "rdlc.finding/v0.2" },
+    "id": { "$ref": "common.schema.json#/$defs/uuidUrn" },
+    "display_id": { "$ref": "common.schema.json#/$defs/displayAlias" },
+    "rule": { "type": "string", "pattern": "^RDLC-[A-Z]+-[0-9]{3}$" },
+    "severity": { "enum": ["info", "advisory", "warning", "blocking"] },
+    "artifact": { "$ref": "common.schema.json#/$defs/uuidUrn" },
+    "artifact_display_id": { "$ref": "common.schema.json#/$defs/displayAlias" },
+    "location": { "type": "string", "minLength": 1 },
+    "message": { "type": "string", "minLength": 1 },
+    "evidence": {
+      "type": "array",
+      "items": { "$ref": "common.schema.json#/$defs/sourceReference" }
+    },
+    "confidence": { "enum": ["low", "medium", "high"] },
+    "suggested_action": { "type": "string" },
+    "status": { "enum": ["open", "resolved", "accepted", "challenged", "waived"] }
+  },
+  "additionalProperties": false
+}

--- a/core/schemas/v0.2/index.mjs
+++ b/core/schemas/v0.2/index.mjs
@@ -1,0 +1,49 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import Ajv2020 from "ajv/dist/2020.js";
+
+const schemaDirectory = dirname(fileURLToPath(import.meta.url));
+
+/** Map of schema_version values to their schema files (spec §12). */
+export const schemaFiles = Object.freeze({
+  "rdlc.artifact/v0.2": "artifact.schema.json",
+  "rdlc.source-snapshot/v0.2": "source-snapshot.schema.json",
+  "rdlc.principal/v0.2": "principal.schema.json",
+  "rdlc.finding/v0.2": "finding.schema.json",
+  "rdlc.work-claim/v0.2": "work-claim.schema.json",
+  "rdlc.lease/v0.2": "lease.schema.json",
+  "rdlc.changeset/v0.2": "changeset.schema.json",
+  "rdlc.project/v0.2": "project.schema.json"
+});
+
+async function loadSchema(name) {
+  return JSON.parse(await readFile(resolve(schemaDirectory, name), "utf8"));
+}
+
+/** Build one Ajv instance with the common definitions and every v0.2 schema registered. */
+export async function createValidator() {
+  const ajv = new Ajv2020({ allErrors: true, strict: true, strictSchema: false, strictRequired: false });
+  ajv.addSchema(await loadSchema("common.schema.json"));
+  for (const file of Object.values(schemaFiles)) ajv.addSchema(await loadSchema(file));
+  return ajv;
+}
+
+/**
+ * Validate a portable record by its declared schema_version.
+ * Fails closed: an unknown or missing schema_version is a failure (spec §7.2, §43).
+ */
+export async function validateRecord(record, ajv) {
+  const validator = ajv ?? await createValidator();
+  const schemaVersion = record?.schema_version;
+  const file = schemaFiles[schemaVersion];
+  if (!file) return { valid: false, failures: [`unknown or missing schema_version: ${schemaVersion}`] };
+  const validate = validator.getSchema(`https://rdlc.dev/schemas/v0.2/${file}`);
+  if (!validate) return { valid: false, failures: [`schema not registered: ${file}`] };
+  const valid = validate(record);
+  return {
+    valid,
+    failures: valid ? [] : (validate.errors ?? []).map((error) => `${error.instancePath || "/"} ${error.message}`)
+  };
+}

--- a/core/schemas/v0.2/lease.schema.json
+++ b/core/schemas/v0.2/lease.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rdlc.dev/schemas/v0.2/lease.schema.json",
+  "title": "R-DLC mutation lease record (spec §35.9)",
+  "type": "object",
+  "required": ["schema_version", "id", "resource", "purpose", "holder", "authority", "acquired_at", "expires_at", "status"],
+  "properties": {
+    "schema_version": { "const": "rdlc.lease/v0.2" },
+    "id": { "$ref": "common.schema.json#/$defs/uuidUrn" },
+    "resource": { "type": "string", "pattern": "^[a-z][a-z0-9+.-]*://\\S+$" },
+    "purpose": {
+      "enum": [
+        "allocate-display-aliases", "publish-baseline", "finalize-approval-package",
+        "migrate", "recover-connector-cursor"
+      ]
+    },
+    "holder": {
+      "type": "object",
+      "required": ["principal"],
+      "properties": {
+        "principal": { "$ref": "common.schema.json#/$defs/uuidUrn" },
+        "host": { "type": "string", "minLength": 1 },
+        "session": { "type": "string", "minLength": 1 },
+        "workstream": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "authority": {
+      "enum": ["git-ref-compare-and-swap", "provider-conditional-create", "protected-branch-record"]
+    },
+    "fencing_token": { "type": "string", "pattern": "^[0-9]{8,}$" },
+    "base_hash": { "$ref": "common.schema.json#/$defs/sha256" },
+    "acquired_at": { "$ref": "common.schema.json#/$defs/rfc3339Utc" },
+    "heartbeat_at": { "$ref": "common.schema.json#/$defs/rfc3339Utc" },
+    "expires_at": { "$ref": "common.schema.json#/$defs/rfc3339Utc" },
+    "status": { "enum": ["active", "released", "expired", "broken"] }
+  },
+  "additionalProperties": false
+}

--- a/core/schemas/v0.2/principal.schema.json
+++ b/core/schemas/v0.2/principal.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rdlc.dev/schemas/v0.2/principal.schema.json",
+  "title": "R-DLC canonical principal and verified bindings (spec §27.2)",
+  "type": "object",
+  "required": ["schema_version", "id", "display_name", "kind", "status"],
+  "properties": {
+    "schema_version": { "const": "rdlc.principal/v0.2" },
+    "id": { "$ref": "common.schema.json#/$defs/uuidUrn" },
+    "display_name": { "type": "string", "minLength": 1 },
+    "kind": { "enum": ["human", "automation"] },
+    "status": { "enum": ["active", "suspended", "retired"] },
+    "roles": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+    "bindings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["provider", "connection", "account_id", "verified_via", "verified_by", "verified_at", "status"],
+        "properties": {
+          "provider": { "type": "string", "minLength": 1 },
+          "connection": { "type": "string", "minLength": 1 },
+          "tenant_id": { "type": "string", "minLength": 1 },
+          "account_id": { "type": "string", "minLength": 1 },
+          "verified_via": {
+            "enum": ["authenticated-self-binding", "directory-synchronization", "administrator-attestation"]
+          },
+          "verified_by": { "$ref": "common.schema.json#/$defs/uuidUrn" },
+          "verified_at": { "$ref": "common.schema.json#/$defs/rfc3339Utc" },
+          "expires_at": { "$ref": "common.schema.json#/$defs/rfc3339Utc" },
+          "status": { "enum": ["verified", "revoked", "expired"] }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/core/schemas/v0.2/project.schema.json
+++ b/core/schemas/v0.2/project.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rdlc.dev/schemas/v0.2/project.schema.json",
+  "title": "R-DLC project manifest (spec §11.1)",
+  "type": "object",
+  "required": ["schema_version", "project"],
+  "properties": {
+    "schema_version": { "const": "rdlc.project/v0.2" },
+    "project": {
+      "type": "object",
+      "required": ["id", "title", "default_space", "authority_mode"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+        "title": { "type": "string", "minLength": 1 },
+        "default_space": { "type": "string", "minLength": 1 },
+        "authority_mode": { "enum": ["files-authoritative", "tracker-authoritative", "governed-bidirectional"] }
+      },
+      "additionalProperties": false
+    },
+    "inputs": { "type": "object" },
+    "knowledge": {
+      "type": "object",
+      "required": ["enabled"],
+      "properties": { "enabled": { "type": "boolean" } },
+      "additionalProperties": true
+    },
+    "company_setup": { "type": "object" },
+    "taxonomy": {
+      "type": "object",
+      "properties": {
+        "hierarchy": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "enum": ["portfolio-epic", "initiative", "epic", "capability", "feature", "story", "task"]
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "templates": { "type": "object" },
+    "approval": { "type": "object" },
+    "collaboration": {
+      "type": "object",
+      "properties": {
+        "lease_authority": {
+          "type": "object",
+          "required": ["kind"],
+          "properties": {
+            "kind": { "enum": ["git-ref-compare-and-swap", "provider-conditional-create", "protected-branch-record"] },
+            "remote": { "type": "string" },
+            "ref_namespace": { "type": "string", "pattern": "^refs/rdlc/" }
+          },
+          "additionalProperties": false
+        },
+        "alias_authority": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": true
+    },
+    "estimation": { "type": "object" },
+    "connectors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "provider", "write_mode"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "provider": { "type": "string", "minLength": 1 },
+          "mapping": { "type": "string", "minLength": 1 },
+          "write_mode": { "enum": ["read-only", "propose", "approve-each-batch", "approved-automation"] }
+        },
+        "additionalProperties": false
+      }
+    },
+    "security": {
+      "type": "object",
+      "properties": {
+        "external_content": { "const": "untrusted" },
+        "secrets_provider": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/core/schemas/v0.2/source-snapshot.schema.json
+++ b/core/schemas/v0.2/source-snapshot.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rdlc.dev/schemas/v0.2/source-snapshot.schema.json",
+  "title": "R-DLC source snapshot (spec §16.1, §16.1.1)",
+  "type": "object",
+  "required": ["schema_version", "id", "provider", "retrieved_at", "source_hash"],
+  "properties": {
+    "schema_version": { "const": "rdlc.source-snapshot/v0.2" },
+    "id": { "$ref": "common.schema.json#/$defs/uuidUrn" },
+    "provider": { "type": "string", "minLength": 1 },
+    "connection": { "type": "string", "minLength": 1 },
+    "organization": { "type": "string", "minLength": 1 },
+    "site": { "type": "string", "minLength": 1 },
+    "project": { "type": "string", "minLength": 1 },
+    "space_id": { "type": "string", "minLength": 1 },
+    "space_key": { "type": "string", "minLength": 1 },
+    "item_id": { "type": "string", "minLength": 1 },
+    "page_id": { "type": "string", "minLength": 1 },
+    "page_version": { "type": "integer", "minimum": 1 },
+    "parent_page_id": { "type": "string", "minLength": 1 },
+    "body_representation": { "type": "string", "minLength": 1 },
+    "subresource": { "type": "string", "minLength": 1 },
+    "revision": { "type": "string", "minLength": 1 },
+    "status": { "type": "string", "minLength": 1 },
+    "title": { "type": "string", "minLength": 1 },
+    "author": { "type": "string", "minLength": 1 },
+    "created_at": { "$ref": "common.schema.json#/$defs/rfc3339Utc" },
+    "version_created_at": { "$ref": "common.schema.json#/$defs/rfc3339Utc" },
+    "retrieved_at": { "$ref": "common.schema.json#/$defs/rfc3339Utc" },
+    "source_hash": { "$ref": "common.schema.json#/$defs/sha256" },
+    "source_url": { "type": "string", "pattern": "^https://" }
+  },
+  "additionalProperties": false,
+  "oneOf": [
+    {
+      "description": "Tracker or generic provider snapshot requires item identity and revision (§16.1).",
+      "required": ["item_id", "revision"]
+    },
+    {
+      "description": "Confluence page snapshot requires immutable page ID and version (§16.1.1).",
+      "required": ["page_id", "page_version", "body_representation"]
+    }
+  ]
+}

--- a/core/schemas/v0.2/work-claim.schema.json
+++ b/core/schemas/v0.2/work-claim.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rdlc.dev/schemas/v0.2/work-claim.schema.json",
+  "title": "R-DLC advisory work claim (spec §35.2)",
+  "type": "object",
+  "required": ["schema_version", "id", "actor", "workstream", "scope", "intent", "created_at", "expires_at", "status"],
+  "properties": {
+    "schema_version": { "const": "rdlc.work-claim/v0.2" },
+    "id": { "$ref": "common.schema.json#/$defs/uuidUrn" },
+    "display_id": { "$ref": "common.schema.json#/$defs/displayAlias" },
+    "actor": { "$ref": "common.schema.json#/$defs/uuidUrn" },
+    "workstream": { "type": "string", "minLength": 1 },
+    "scope": {
+      "type": "object",
+      "minProperties": 1,
+      "properties": {
+        "requirements": { "type": "array", "items": { "$ref": "common.schema.json#/$defs/uuidUrn" } },
+        "acceptance_criteria": { "type": "array", "items": { "$ref": "common.schema.json#/$defs/uuidUrn" } },
+        "components": { "type": "array", "items": { "$ref": "common.schema.json#/$defs/uuidUrn" } },
+        "planning_items": { "type": "array", "items": { "$ref": "common.schema.json#/$defs/uuidUrn" } }
+      },
+      "additionalProperties": false
+    },
+    "intent": { "type": "string", "minLength": 1 },
+    "created_at": { "$ref": "common.schema.json#/$defs/rfc3339Utc" },
+    "expires_at": { "$ref": "common.schema.json#/$defs/rfc3339Utc" },
+    "status": { "enum": ["active", "released", "expired"] }
+  },
+  "additionalProperties": false
+}

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -67,10 +67,23 @@
         "§13",
         "§16.1"
       ],
-      "status": "planned",
+      "status": "verified",
       "evidence": {
-        "implementation": [],
-        "tests": []
+        "implementation": [
+          "core/schemas/v0.2/common.schema.json",
+          "core/schemas/v0.2/artifact.schema.json",
+          "core/schemas/v0.2/source-snapshot.schema.json",
+          "core/schemas/v0.2/principal.schema.json",
+          "core/schemas/v0.2/finding.schema.json",
+          "core/schemas/v0.2/work-claim.schema.json",
+          "core/schemas/v0.2/lease.schema.json",
+          "core/schemas/v0.2/changeset.schema.json",
+          "core/schemas/v0.2/project.schema.json",
+          "core/schemas/v0.2/index.mjs"
+        ],
+        "tests": [
+          "tests/governance/schemas.test.mjs"
+        ]
       }
     },
     {

--- a/fixtures/spec-examples/README.md
+++ b/fixtures/spec-examples/README.md
@@ -1,0 +1,19 @@
+# Specification example fixtures
+
+Each file reproduces a specification example verbatim, except that
+placeholder values the spec elides (`sha256:...`, `optional-provider-token`)
+are expanded to schema-valid concrete values so the fixtures can be validated
+strictly. Every substitution is limited to placeholder literals; no field is
+added, removed, or renamed relative to the specification text.
+
+| Fixture | Specification section |
+|---|---|
+| artifact.yaml | §12.3 Common envelope |
+| source-snapshot-jira.yaml | §16.1 Source snapshots |
+| source-snapshot-confluence.yaml | §16.1.1 Confluence page snapshots |
+| finding.yaml | §24.3 Finding contract |
+| principal.yaml | §27.2 Identity registry |
+| changeset.yaml | §33.1 Changeset example |
+| work-claim.yaml | §35.2 Work claims |
+| lease.yaml | §35.9 Mutation leases |
+| project.yaml | §11.1 Project manifest |

--- a/fixtures/spec-examples/artifact.yaml
+++ b/fixtures/spec-examples/artifact.yaml
@@ -1,0 +1,28 @@
+schema_version: rdlc.artifact/v0.2
+id: urn:uuid:0198b7e0-6a2f-7b41-8d3e-2f7c9a6b4d10
+display_id: REQ-104
+project: checkout-modernization
+type: functional-requirement
+title: Preserve an incomplete checkout
+governance_state: draft
+version: 3
+origin:
+  kind: user-capture
+  actor: urn:uuid:0198b7c0-2d5e-7f31-9a43-2c8e5b6a7012
+  captured_at: 2026-08-15T15:00:00Z
+statement: >-
+  The checkout service shall preserve an authenticated customer's incomplete
+  checkout for the configured retention period.
+rationale: Reduce abandonment after interruption.
+owner: role:product-owner
+sources:
+  - kb://product/customer-research/interrupted-checkout
+  - external://jira/commerce/DISC-42#comment-10017
+relationships:
+  - type: derives-from
+    target: urn:uuid:0198b7d0-5b1e-7a30-9c2d-1e6b8f5a3c09
+  - type: affects
+    target: urn:uuid:0198b7d5-8c4a-7d22-a142-6b5e3c9f7011
+external_refs: []
+created_at: 2026-08-15T15:00:00Z
+updated_at: 2026-08-15T16:12:00Z

--- a/fixtures/spec-examples/changeset.yaml
+++ b/fixtures/spec-examples/changeset.yaml
@@ -1,0 +1,23 @@
+schema_version: rdlc.changeset/v0.2
+id: urn:uuid:0198b830-5a1e-7c42-9d63-2b4f6a8c0e12
+display_id: CS-20260815-01
+connection: delivery-jira
+created_by: urn:uuid:0198b7c0-2d5e-7f31-9a43-2c8e5b6a7012
+created_at: 2026-08-15T18:00:00Z
+mode: approve-each-batch
+operations:
+  - operation_id: op-001
+    action: create
+    artifact: urn:uuid:0198b810-1a2b-7c3d-8e4f-1029384756aa
+    target:
+      project: COM
+      work_type: Story
+    idempotency_key: rdlc:0198b810-1a2b-7c3d-8e4f-1029384756aa
+  - operation_id: op-002
+    action: link
+    source: urn:uuid:0198b810-1a2b-7c3d-8e4f-1029384756aa
+    relation: blocked-by
+    target: urn:uuid:0198b805-0f1e-7d2c-9b3a-a1b2c3d4e5f6
+approval:
+  required: true
+  status: pending

--- a/fixtures/spec-examples/finding.yaml
+++ b/fixtures/spec-examples/finding.yaml
@@ -1,0 +1,14 @@
+schema_version: rdlc.finding/v0.2
+id: urn:uuid:0198b820-7f2a-72d6-a341-4c5e6f708192
+display_id: F-017
+rule: RDLC-AC-004
+severity: blocking
+artifact: urn:uuid:0198b7e0-6a2f-7b41-8d3e-2f7c9a6b4d10
+artifact_display_id: REQ-104
+location: acceptance_criteria[1]
+message: Expected retention duration is not bounded.
+evidence:
+  - kb://payments-policy/retention/incomplete-checkout
+confidence: high
+suggested_action: Reference the configured retention policy and define expiry behavior.
+status: open

--- a/fixtures/spec-examples/lease.yaml
+++ b/fixtures/spec-examples/lease.yaml
@@ -1,0 +1,16 @@
+schema_version: rdlc.lease/v0.2
+id: urn:uuid:0198b9b0-103a-74c6-8912-1a2b3c4d5e6f
+resource: alias-authority://commerce/requirement
+purpose: allocate-display-aliases
+holder:
+  principal: urn:uuid:0198b7c0-2d5e-7f31-9a43-2c8e5b6a7012
+  host: codex
+  session: session-913
+  workstream: checkout-recovery-stories
+authority: provider-conditional-create
+fencing_token: "00000042"
+base_hash: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+acquired_at: 2026-08-15T19:02:00Z
+heartbeat_at: 2026-08-15T19:02:30Z
+expires_at: 2026-08-15T19:04:00Z
+status: active

--- a/fixtures/spec-examples/principal.yaml
+++ b/fixtures/spec-examples/principal.yaml
@@ -1,0 +1,16 @@
+schema_version: rdlc.principal/v0.2
+id: urn:uuid:0198b7c0-2d5e-7f31-9a43-2c8e5b6a7012
+display_name: Alex Morgan
+kind: human
+status: active
+roles:
+  - product-owner
+bindings:
+  - provider: jira
+    connection: delivery-jira
+    tenant_id: 3f9c2a10
+    account_id: abc123-immutable-provider-id
+    verified_via: authenticated-self-binding
+    verified_by: urn:uuid:0198b7c0-2d5e-7f31-9a43-2c8e5b6a7012
+    verified_at: 2026-08-15T17:40:00Z
+    status: verified

--- a/fixtures/spec-examples/project.yaml
+++ b/fixtures/spec-examples/project.yaml
@@ -1,0 +1,84 @@
+schema_version: rdlc.project/v0.2
+
+project:
+  id: checkout-modernization
+  title: Checkout Modernization
+  default_space: commerce
+  authority_mode: files-authoritative
+
+inputs:
+  scope_documents:
+    - path: inputs/checkout-modernization-scope.docx
+      role: primary-scope
+  confluence:
+    - connection: product-confluence
+      space_ids:
+        - "98421"
+      root_page_ids:
+        - "123456"
+      include_descendants: true
+      include:
+        - pages
+        - attachments
+        - comments
+      mode: read-only
+
+knowledge:
+  enabled: false
+
+company_setup:
+  profile: config/company/delivery-profile.yaml
+  discovery: merge-profile-and-tracker
+  unknown_issue_type_policy: ask
+
+taxonomy:
+  profile: product-delivery
+  portfolio_enabled: true
+  hierarchy:
+    - portfolio-epic
+    - initiative
+    - epic
+    - capability
+    - feature
+    - story
+    - task
+
+templates:
+  packs:
+    - core
+    - organization
+    - commerce
+
+approval:
+  default_policy: all-required-by-role
+  material_change_policy: invalidate-affected
+
+collaboration:
+  lease_authority:
+    kind: git-ref-compare-and-swap
+    remote: origin
+    ref_namespace: refs/rdlc/leases
+  alias_authority: lease-protected-counter
+
+estimation:
+  default_profile: team-story-points
+  allow_ai_suggestions: true
+  confirmation_required: true
+
+connectors:
+  - id: product-confluence
+    provider: confluence-cloud
+    mapping: config/sources/confluence-product.yaml
+    write_mode: read-only
+  - id: delivery-jira
+    provider: jira
+    mapping: config/connectors/jira-commerce.yaml
+    write_mode: approve-each-batch
+  - id: engineering-github
+    provider: github
+    mapping: config/connectors/github-engineering.yaml
+    write_mode: propose
+
+security:
+  external_content: untrusted
+  secrets_provider: environment

--- a/fixtures/spec-examples/source-snapshot-confluence.yaml
+++ b/fixtures/spec-examples/source-snapshot-confluence.yaml
@@ -1,0 +1,18 @@
+schema_version: rdlc.source-snapshot/v0.2
+id: urn:uuid:0198ba20-53e1-7c92-a647-3b5d7f9012c4
+provider: confluence-cloud
+connection: product-confluence
+site: example.atlassian.net/wiki
+space_id: "98421"
+space_key: PAY
+page_id: "123456"
+page_version: 19
+status: current
+title: Checkout Recovery Requirements
+parent_page_id: "120000"
+body_representation: storage
+author: confluence-account:abc123
+version_created_at: 2026-08-14T21:20:00Z
+retrieved_at: 2026-08-15T14:32:00Z
+source_hash: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+source_url: https://example.atlassian.net/wiki/spaces/PAY/pages/123456

--- a/fixtures/spec-examples/source-snapshot-jira.yaml
+++ b/fixtures/spec-examples/source-snapshot-jira.yaml
@@ -1,0 +1,13 @@
+schema_version: rdlc.source-snapshot/v0.2
+id: urn:uuid:0198ba10-64f2-70a1-9c35-2d4e6f8091a3
+provider: jira
+organization: example.atlassian.net
+project: COM
+item_id: COM-42
+subresource: comment:10017
+revision: "2026-08-15T14:31:22Z"
+author: jira-account:abc123
+created_at: 2026-08-15T14:20:00Z
+retrieved_at: 2026-08-15T14:32:00Z
+source_hash: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+source_url: https://example.atlassian.net/browse/COM-42

--- a/fixtures/spec-examples/work-claim.yaml
+++ b/fixtures/spec-examples/work-claim.yaml
@@ -1,0 +1,16 @@
+schema_version: rdlc.work-claim/v0.2
+id: urn:uuid:0198b840-4b2c-79e1-8f56-3d7a9c1e5b20
+display_id: CL-17
+actor: urn:uuid:0198b7c0-2d5e-7f31-9a43-2c8e5b6a7012
+workstream: checkout-recovery-stories
+scope:
+  requirements:
+    - urn:uuid:0198b7e0-6a2f-7b41-8d3e-2f7c9a6b4d10
+  acceptance_criteria:
+    - urn:uuid:0198b7e4-3c1d-7a20-b954-7e6d5c4b3a21
+  components:
+    - urn:uuid:0198b7d5-8c4a-7d22-a142-6b5e3c9f7011
+intent: Create recovery and expiration stories.
+created_at: 2026-08-15T19:00:00Z
+expires_at: 2026-08-16T19:00:00Z
+status: active

--- a/tests/governance/schemas.test.mjs
+++ b/tests/governance/schemas.test.mjs
@@ -123,3 +123,9 @@ test("FEAT-002: work claim scope must not be empty", async () => {
   record.scope = {};
   assert.equal((await validateRecord(record, ajv)).valid, false);
 });
+
+test("FEAT-002: changeset link target must be a UUID URN, not a display alias", async () => {
+  const record = await loadFixture("changeset.yaml");
+  record.operations[1].target = "COM-104";
+  assert.equal((await validateRecord(record, ajv)).valid, false);
+});

--- a/tests/governance/schemas.test.mjs
+++ b/tests/governance/schemas.test.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { readFile, readdir } from "node:fs/promises";
+import test from "node:test";
+
+import YAML from "yaml";
+
+import { createValidator, schemaFiles, validateRecord } from "../../core/schemas/v0.2/index.mjs";
+
+const ajv = await createValidator();
+
+async function loadFixture(name) {
+  return YAML.parse(await readFile(`fixtures/spec-examples/${name}`, "utf8"));
+}
+
+test("FEAT-002: every specification example fixture validates against its schema", async () => {
+  const entries = (await readdir("fixtures/spec-examples")).filter((name) => name.endsWith(".yaml"));
+  assert.ok(entries.length >= 9, "all nine spec-example fixtures are present");
+  for (const name of entries) {
+    const record = await loadFixture(name);
+    const { valid, failures } = await validateRecord(record, ajv);
+    assert.ok(valid, `${name}: ${failures.join("; ")}`);
+  }
+});
+
+test("FEAT-002: every declared schema_version resolves to a registered schema", async () => {
+  for (const [version, file] of Object.entries(schemaFiles)) {
+    assert.ok(ajv.getSchema(`https://rdlc.dev/schemas/v0.2/${file}`), `${version} -> ${file}`);
+  }
+});
+
+test("FEAT-002: unknown schema_version fails closed", async () => {
+  const { valid, failures } = await validateRecord({ schema_version: "rdlc.artifact/v9.9" }, ajv);
+  assert.equal(valid, false);
+  assert.match(failures[0], /unknown or missing schema_version/);
+});
+
+test("FEAT-002: envelope rejects missing canonical identity", async () => {
+  const record = await loadFixture("artifact.yaml");
+  delete record.id;
+  const { valid } = await validateRecord(record, ajv);
+  assert.equal(valid, false);
+});
+
+test("FEAT-002: envelope rejects a non-v7 or malformed UUID URN", async () => {
+  const record = await loadFixture("artifact.yaml");
+  for (const bad of [
+    "urn:uuid:0198b7e0-6a2f-4b41-8d3e-2f7c9a6b4d10",
+    "urn:uuid:not-a-uuid",
+    "0198b7e0-6a2f-7b41-8d3e-2f7c9a6b4d10"
+  ]) {
+    const { valid } = await validateRecord({ ...record, id: bad }, ajv);
+    assert.equal(valid, false, `must reject id ${bad}`);
+  }
+});
+
+test("FEAT-002: envelope rejects an unknown governance state", async () => {
+  const record = await loadFixture("artifact.yaml");
+  const { valid } = await validateRecord({ ...record, governance_state: "published" }, ajv);
+  assert.equal(valid, false);
+});
+
+test("FEAT-002: relationship targets must be UUID URNs, never display aliases", async () => {
+  const record = await loadFixture("artifact.yaml");
+  record.relationships = [{ type: "derives-from", target: "REQ-103" }];
+  const { valid } = await validateRecord(record, ajv);
+  assert.equal(valid, false);
+});
+
+test("FEAT-002: relationship type outside §13 is rejected", async () => {
+  const record = await loadFixture("artifact.yaml");
+  record.relationships = [
+    { type: "related-to", target: "urn:uuid:0198b7d0-5b1e-7a30-9c2d-1e6b8f5a3c09" }
+  ];
+  const { valid } = await validateRecord(record, ajv);
+  assert.equal(valid, false);
+});
+
+test("FEAT-002: source snapshot requires provider revision identity", async () => {
+  const jira = await loadFixture("source-snapshot-jira.yaml");
+  delete jira.revision;
+  assert.equal((await validateRecord(jira, ajv)).valid, false);
+
+  const confluence = await loadFixture("source-snapshot-confluence.yaml");
+  delete confluence.page_version;
+  assert.equal((await validateRecord(confluence, ajv)).valid, false);
+});
+
+test("FEAT-002: hash fields require lowercase sha256:<64 hex>", async () => {
+  const record = await loadFixture("source-snapshot-jira.yaml");
+  for (const bad of ["sha256:...", "sha256:ABC", "md5:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]) {
+    assert.equal((await validateRecord({ ...record, source_hash: bad }, ajv)).valid, false, bad);
+  }
+});
+
+test("FEAT-002: principal binding requires verification fields; unverified match is not a binding", async () => {
+  const record = await loadFixture("principal.yaml");
+  delete record.bindings[0].verified_via;
+  assert.equal((await validateRecord(record, ajv)).valid, false);
+});
+
+test("FEAT-002: changeset create operations require artifact, target, and idempotency key", async () => {
+  const record = await loadFixture("changeset.yaml");
+  delete record.operations[0].idempotency_key;
+  assert.equal((await validateRecord(record, ajv)).valid, false);
+});
+
+test("FEAT-002: lease requires an authority, expiry, and known purpose", async () => {
+  const record = await loadFixture("lease.yaml");
+  assert.equal((await validateRecord({ ...record, purpose: "anything" }, ajv)).valid, false);
+  const noExpiry = await loadFixture("lease.yaml");
+  delete noExpiry.expires_at;
+  assert.equal((await validateRecord(noExpiry, ajv)).valid, false);
+});
+
+test("FEAT-002: project manifest requires declared authority mode and rejects unknown modes", async () => {
+  const record = await loadFixture("project.yaml");
+  record.project.authority_mode = "database-authoritative";
+  assert.equal((await validateRecord(record, ajv)).valid, false);
+});
+
+test("FEAT-002: work claim scope must not be empty", async () => {
+  const record = await loadFixture("work-claim.yaml");
+  record.scope = {};
+  assert.equal((await validateRecord(record, ajv)).valid, false);
+});


### PR DESCRIPTION
## Outcome

Implements the portable v0.2 schema set and common artifact envelope: JSON Schemas for the artifact envelope, relationships, source snapshots (tracker and Confluence), principals with verified bindings, findings, work claims, mutation leases, changesets, and the project manifest, plus a fail-closed schema_version-dispatch validator and verbatim specification-example fixtures.

Closes #3

## Traceability

- Requirement IDs: FEAT-002
- Specification sections: §11.1, §12.1–12.4, §13, §16.1, §16.1.1, §24.3, §27.2, §33.1, §35.2, §35.9
- Conformance modules affected: Core
- Traceability index updated: yes — FEAT-002 verified with schema and test evidence

## Gate evidence

- [x] Feature/requirement definition is complete and linked.
- [x] Implementation plan received the required review (ADR-001 dispositions #2 fixed identity/hash/lease choices).
- [x] Development stayed within issue scope.
- [x] Deterministic tests cover acceptance and failure criteria.
- [x] Final review considered correctness, security, and traceability.

Commands and results:

```text
npm test
> check:governance — Governance verified: 13 traceable requirements and 5 development gates.
> test:governance — 23 pass, 0 fail (9 spec-example fixtures validate; negative tests: missing identity, non-v7 UUIDs, unknown states, alias-as-target, unknown relationship type, missing revisions, malformed hashes, unverified bindings, missing idempotency key, unknown lease purpose, empty claim scope, unknown authority mode)
```

Note: spec-example fixtures reproduce specification examples verbatim except placeholder literals (`sha256:...`) expanded to schema-valid values; documented in fixtures/spec-examples/README.md.

## Security, privacy, rights, and retention

Schemas enforce fail-closed validation (unknown schema_version rejected), canonical-identity-only relationship targets, verified-binding requirements (§27.2), and untrusted external-content declaration in the project manifest. No secrets; no protected harness file touched.

## Compatibility, migration, and rollback

New additive schema files; no durable contract existed before. x-rdlc-governed / x-rdlc-set-keys annotations reserved for FEAT-003 hashing per ADR-001 item 6. Rollback = revert.

## Release and documentation

First Core-module capability; conformance claims unchanged until REL-001.
