### PR TITLE
feat: rdlc-jcs-v1 canonical serialization and hash profiles (#4) [FEAT-003]

### DIFF
--- a/core/lib/canonical.mjs
+++ b/core/lib/canonical.mjs
@@ -1,0 +1,248 @@
+/**
+ * rdlc-jcs-v1 canonical serialization and hash profiles (spec §12.5, §12.6).
+ *
+ * Canonicalization parses the schema-valid logical artifact, normalizes
+ * strings to Unicode NFC, normalizes hash-included timestamps to RFC 3339 UTC
+ * with a Z suffix, sorts set-like arrays by their schema-declared keys,
+ * serializes with RFC 8785 JCS, and hashes the UTF-8 canonical bytes with
+ * SHA-256. Every operation fails closed (§12.5).
+ */
+
+import { createHash } from "node:crypto";
+
+import rfc8785 from "canonicalize";
+import YAML from "yaml";
+
+export const HASH_PROFILE_VERSION = "rdlc-jcs-v1";
+
+export class CanonicalizationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "CanonicalizationError";
+  }
+}
+
+const TIMESTAMP_PATTERN = /^(\d{4}-\d{2}-\d{2})[Tt](\d{2}:\d{2}:\d{2})(\.\d+)?([Zz]|[+-]\d{2}:\d{2})$/;
+const UTC_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
+
+/**
+ * Normalize an RFC 3339 instant to UTC with a Z suffix (§12.6).
+ * Fractional-second digits are preserved as written when already UTC;
+ * offset instants are converted using millisecond precision.
+ */
+export function normalizeTimestamp(value) {
+  if (typeof value !== "string" || !TIMESTAMP_PATTERN.test(value)) {
+    throw new CanonicalizationError(`not an RFC 3339 instant: ${value}`);
+  }
+  if (UTC_TIMESTAMP_PATTERN.test(value)) return value;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) throw new CanonicalizationError(`unparseable instant: ${value}`);
+  return parsed.toISOString().replace(/\.000Z$/, "Z");
+}
+
+/**
+ * Parse YAML or JSON source text rejecting duplicate object keys (§12.5 item 2).
+ */
+export function parseStrict(text) {
+  const document = YAML.parseDocument(text, { uniqueKeys: true, prettyErrors: false });
+  if (document.errors.length) {
+    throw new CanonicalizationError(`source cannot be parsed safely: ${document.errors[0].message}`);
+  }
+  return document.toJS({ maxAliasCount: 100 });
+}
+
+function isTimestampLike(value) {
+  return typeof value === "string" && TIMESTAMP_PATTERN.test(value);
+}
+
+function compareByKeys(keys) {
+  return (a, b) => {
+    for (const key of keys) {
+      const left = a?.[key];
+      const right = b?.[key];
+      if (left === right) continue;
+      if (left === undefined) return -1;
+      if (right === undefined) return 1;
+      const l = String(left);
+      const r = String(right);
+      if (l < r) return -1;
+      if (l > r) return 1;
+    }
+    return 0;
+  };
+}
+
+/**
+ * Recursively normalize a parsed value for canonicalization:
+ * NFC strings, normalized UTC timestamps, schema-hinted set-array sorting,
+ * and I-JSON number validation (§12.5 items 3–6).
+ *
+ * `hints` mirrors the schema's `x-rdlc-set-keys` map: property name ->
+ * array of sort keys (sorted as a set) or null (order-significant).
+ */
+export function normalizeValue(value, hints = {}, path = "$") {
+  if (value === null || typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new CanonicalizationError(`non-finite number at ${path}`);
+    if (Number.isInteger(value) && !Number.isSafeInteger(value)) {
+      throw new CanonicalizationError(`integer outside the I-JSON safe range must be a schema-defined string at ${path}`);
+    }
+    return value;
+  }
+  if (typeof value === "string") {
+    const normalized = value.normalize("NFC");
+    return isTimestampLike(normalized) ? normalizeTimestamp(normalized) : normalized;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry, index) => normalizeValue(entry, hints, `${path}[${index}]`));
+  }
+  if (typeof value === "object") {
+    const result = {};
+    for (const [key, entry] of Object.entries(value)) {
+      if (entry === undefined) continue;
+      const childPath = `${path}.${key}`;
+      let normalized = normalizeValue(entry, hints, childPath);
+      const setKeys = hints[key];
+      if (Array.isArray(setKeys) && Array.isArray(normalized)) {
+        normalized = [...normalized].sort(compareByKeys(setKeys));
+      }
+      result[key] = normalized;
+    }
+    return result;
+  }
+  throw new CanonicalizationError(`unsupported value type ${typeof value} at ${path}`);
+}
+
+/** Serialize a normalized value with RFC 8785 JCS (§12.5 item 7). */
+export function canonicalBytes(value, hints = {}) {
+  const serialized = rfc8785(normalizeValue(value, hints));
+  if (typeof serialized !== "string") throw new CanonicalizationError("value cannot be canonicalized");
+  return Buffer.from(serialized, "utf8");
+}
+
+function sha256(bytes) {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+function stampedHash(hash, profile) {
+  return Object.freeze({ hash, hash_profile: HASH_PROFILE_VERSION, profile });
+}
+
+/** source_hash: original retained source bytes exactly as received (§12.5). */
+export function sourceHash(bytes) {
+  if (!(bytes instanceof Uint8Array)) throw new CanonicalizationError("source bytes are required");
+  return stampedHash(sha256(bytes), "source_hash");
+}
+
+const CONTENT_EXCLUDED_FIELDS = Object.freeze([
+  "content_hash", "display_id", "created_at", "updated_at", "external_refs"
+]);
+
+/**
+ * content_hash: schema-declared semantic fields and governed relationships,
+ * excluding presentation, aliases, audit, receipts, and operational
+ * timestamps (§12.5). `schema` supplies x-rdlc-governed and x-rdlc-set-keys.
+ */
+export function contentHash(record, schema) {
+  if (!record?.schema_version) throw new CanonicalizationError("record schema_version is required");
+  const governed = schema?.["x-rdlc-governed"];
+  if (!Array.isArray(governed) || governed.length === 0) {
+    throw new CanonicalizationError(`schema does not declare x-rdlc-governed fields for ${record.schema_version}`);
+  }
+  const projection = { schema_version: record.schema_version, id: record.id };
+  for (const field of governed) {
+    if (CONTENT_EXCLUDED_FIELDS.includes(field)) {
+      throw new CanonicalizationError(`excluded field cannot be governed: ${field}`);
+    }
+    if (record[field] !== undefined) projection[field] = record[field];
+  }
+  const bytes = canonicalBytes(projection, schema?.["x-rdlc-set-keys"] ?? {});
+  return { ...stampedHash(sha256(bytes), "content_hash"), schema_version: record.schema_version };
+}
+
+/**
+ * approval_package_hash: ordered artifact content hashes, locks, policy
+ * versions, approver set, blocking findings, waivers, and material diff;
+ * decisions and signatures are excluded (§12.5).
+ */
+export function approvalPackageHash(pkg) {
+  for (const field of ["artifact_hashes", "policy_versions", "required_approvers"]) {
+    if (!Array.isArray(pkg?.[field]) || pkg[field].length === 0) {
+      throw new CanonicalizationError(`approval package requires non-empty ${field}`);
+    }
+  }
+  for (const field of ["decisions", "signatures"]) {
+    if (pkg[field] !== undefined) throw new CanonicalizationError(`approval package must not embed ${field}`);
+  }
+  const projection = {
+    artifact_hashes: pkg.artifact_hashes,
+    source_locks: pkg.source_locks ?? [],
+    kb_lock: pkg.kb_lock ?? null,
+    policy_versions: pkg.policy_versions,
+    required_approvers: pkg.required_approvers,
+    blocking_findings: pkg.blocking_findings ?? [],
+    waivers: pkg.waivers ?? [],
+    material_diff: pkg.material_diff ?? null
+  };
+  const bytes = canonicalBytes(projection, { required_approvers: ["principal"], source_locks: ["id"] });
+  return stampedHash(sha256(bytes), "approval_package_hash");
+}
+
+/**
+ * baseline_root_hash: canonical manifest of approval-package hashes, artifact
+ * hashes, source locks, adopted redaction tombstones, and baseline metadata;
+ * signatures and later addenda are excluded (§12.5).
+ */
+export function baselineRootHash(manifest) {
+  for (const field of ["approval_package_hashes", "artifact_hashes"]) {
+    if (!Array.isArray(manifest?.[field]) || manifest[field].length === 0) {
+      throw new CanonicalizationError(`baseline manifest requires non-empty ${field}`);
+    }
+  }
+  const projection = {
+    approval_package_hashes: manifest.approval_package_hashes,
+    artifact_hashes: manifest.artifact_hashes,
+    source_locks: manifest.source_locks ?? [],
+    adopted_redaction_tombstones: manifest.adopted_redaction_tombstones ?? [],
+    metadata: manifest.metadata ?? {}
+  };
+  const bytes = canonicalBytes(projection, {});
+  return stampedHash(sha256(bytes), "baseline_root_hash");
+}
+
+/**
+ * redaction_addendum_hash: original baseline root, ordered tombstones,
+ * authority, storage boundary, and resulting availability state (§12.5).
+ */
+export function redactionAddendumHash(addendum) {
+  for (const field of ["original_baseline_root", "tombstones", "authority", "storage_boundary", "availability_state"]) {
+    if (addendum?.[field] === undefined || (Array.isArray(addendum[field]) && addendum[field].length === 0)) {
+      throw new CanonicalizationError(`redaction addendum requires ${field}`);
+    }
+  }
+  const projection = {
+    original_baseline_root: addendum.original_baseline_root,
+    tombstones: addendum.tombstones,
+    authority: addendum.authority,
+    storage_boundary: addendum.storage_boundary,
+    availability_state: addendum.availability_state
+  };
+  const bytes = canonicalBytes(projection, {});
+  return stampedHash(sha256(bytes), "redaction_addendum_hash");
+}
+
+/**
+ * readback_hash: provider-normalized fields selected by the versioned
+ * connector mapping; everything outside the mapping is excluded (§12.5).
+ */
+export function readbackHash(providerFields, mapping) {
+  if (!mapping?.version || !Array.isArray(mapping.fields) || mapping.fields.length === 0) {
+    throw new CanonicalizationError("connector mapping version and fields are required");
+  }
+  const projection = { mapping_version: mapping.version, fields: {} };
+  for (const field of mapping.fields) {
+    projection.fields[field] = providerFields?.[field] === undefined ? null : providerFields[field];
+  }
+  const bytes = canonicalBytes(projection, {});
+  return { ...stampedHash(sha256(bytes), "readback_hash"), mapping_version: mapping.version };
+}

--- a/core/lib/canonical.mjs
+++ b/core/lib/canonical.mjs
@@ -113,7 +113,7 @@ export function normalizeValue(value, hints = {}, path = "$") {
     for (const [rawKey, entry] of Object.entries(value)) {
       if (entry === undefined) continue;
       const key = rawKey.normalize("NFC");
-      if (key !== rawKey && Object.hasOwn(value, key)) {
+      if (Object.hasOwn(result, key)) {
         throw new CanonicalizationError(`NFC key collision at ${path}.${key}`);
       }
       const childPath = `${path}.${key}`;

--- a/core/lib/canonical.mjs
+++ b/core/lib/canonical.mjs
@@ -26,18 +26,25 @@ const TIMESTAMP_PATTERN = /^(\d{4}-\d{2}-\d{2})[Tt](\d{2}:\d{2}:\d{2})(\.\d+)?([
 const UTC_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
 
 /**
- * Normalize an RFC 3339 instant to UTC with a Z suffix (§12.6).
- * Fractional-second digits are preserved as written when already UTC;
- * offset instants are converted using millisecond precision.
+ * Normalize an RFC 3339 instant to UTC with a Z suffix at exactly the
+ * profile's canonical millisecond precision (§12.5 item 4, §12.6).
+ *
+ * The canonical form is injective: one instant has exactly one canonical
+ * string regardless of how the producer wrote it (offset, missing or padded
+ * fraction). Sub-millisecond precision that carries information fails closed
+ * rather than being silently truncated.
  */
 export function normalizeTimestamp(value) {
-  if (typeof value !== "string" || !TIMESTAMP_PATTERN.test(value)) {
-    throw new CanonicalizationError(`not an RFC 3339 instant: ${value}`);
+  const match = typeof value === "string" ? value.match(TIMESTAMP_PATTERN) : null;
+  if (!match) throw new CanonicalizationError(`not an RFC 3339 instant: ${value}`);
+  const fraction = match[3] ? match[3].slice(1) : "";
+  if (fraction.length > 3 && /[1-9]/.test(fraction.slice(3))) {
+    throw new CanonicalizationError(`sub-millisecond precision exceeds the canonical profile precision: ${value}`);
   }
-  if (UTC_TIMESTAMP_PATTERN.test(value)) return value;
-  const parsed = new Date(value);
+  const milliseconds = fraction.slice(0, 3).padEnd(3, "0");
+  const parsed = new Date(`${match[1]}T${match[2]}.${milliseconds}${match[4].toUpperCase()}`);
   if (Number.isNaN(parsed.getTime())) throw new CanonicalizationError(`unparseable instant: ${value}`);
-  return parsed.toISOString().replace(/\.000Z$/, "Z");
+  return parsed.toISOString();
 }
 
 /**
@@ -63,12 +70,17 @@ function compareByKeys(keys) {
       if (left === right) continue;
       if (left === undefined) return -1;
       if (right === undefined) return 1;
+      if (typeof left === "number" && typeof right === "number") return left - right;
       const l = String(left);
       const r = String(right);
       if (l < r) return -1;
       if (l > r) return 1;
     }
-    return 0;
+    // Deterministic tie-break: entries equal on every declared key compare by
+    // their full canonical serialization, so hashes never depend on producer order.
+    const l = rfc8785(a) ?? "";
+    const r = rfc8785(b) ?? "";
+    return l < r ? -1 : l > r ? 1 : 0;
   };
 }
 
@@ -98,8 +110,12 @@ export function normalizeValue(value, hints = {}, path = "$") {
   }
   if (typeof value === "object") {
     const result = {};
-    for (const [key, entry] of Object.entries(value)) {
+    for (const [rawKey, entry] of Object.entries(value)) {
       if (entry === undefined) continue;
+      const key = rawKey.normalize("NFC");
+      if (key !== rawKey && Object.hasOwn(value, key)) {
+        throw new CanonicalizationError(`NFC key collision at ${path}.${key}`);
+      }
       const childPath = `${path}.${key}`;
       let normalized = normalizeValue(entry, hints, childPath);
       const setKeys = hints[key];

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -94,10 +94,15 @@
         "§12.5",
         "§12.6"
       ],
-      "status": "planned",
+      "status": "verified",
       "evidence": {
-        "implementation": [],
-        "tests": []
+        "implementation": [
+          "core/lib/canonical.mjs",
+          "fixtures/canonical/kat.json"
+        ],
+        "tests": [
+          "tests/governance/canonical.test.mjs"
+        ]
       }
     },
     {

--- a/fixtures/canonical/kat.json
+++ b/fixtures/canonical/kat.json
@@ -1,0 +1,176 @@
+{
+  "profile": "rdlc-jcs-v1",
+  "cases": [
+    {
+      "name": "unicode-nfc-normalization",
+      "kind": "canonical",
+      "input": {
+        "text": "café",
+        "plain": "café"
+      },
+      "hints": {},
+      "expected_canonical": "{\"plain\":\"café\",\"text\":\"café\"}",
+      "expected_hash": "sha256:4f318c37d9e9b43f7f8fb74bea5b719be7c251dc810e176b0a2c4723db5e56a0"
+    },
+    {
+      "name": "timestamp-offset-to-utc",
+      "kind": "canonical",
+      "input": {
+        "at": "2026-08-15T19:02:00+02:00",
+        "already": "2026-08-15T17:02:00Z",
+        "fractional": "2026-08-15T17:02:00.250Z"
+      },
+      "hints": {},
+      "expected_canonical": "{\"already\":\"2026-08-15T17:02:00Z\",\"at\":\"2026-08-15T17:02:00Z\",\"fractional\":\"2026-08-15T17:02:00.250Z\"}",
+      "expected_hash": "sha256:49767fc5547e9f724b6f2c718d68d00a8c003ac870a5bdb89931c83a640d95a4"
+    },
+    {
+      "name": "numeric-boundaries",
+      "kind": "canonical",
+      "input": {
+        "safeMax": 9007199254740991,
+        "negative": -42,
+        "zero": 0,
+        "fraction": 0.30000000000000004,
+        "small": 1e-21
+      },
+      "hints": {},
+      "expected_canonical": "{\"fraction\":0.30000000000000004,\"negative\":-42,\"safeMax\":9007199254740991,\"small\":1e-21,\"zero\":0}",
+      "expected_hash": "sha256:209be5b579cd2efe1ce9566b6b692e09905e2d0a8d01c906ab5ee056f01b939e"
+    },
+    {
+      "name": "set-like-array-sorted",
+      "kind": "canonical",
+      "input": {
+        "relationships": [
+          {
+            "type": "satisfies",
+            "target": "urn:uuid:0198b7d5-8c4a-7d22-a142-6b5e3c9f7011"
+          },
+          {
+            "type": "derives-from",
+            "target": "urn:uuid:0198b7d0-5b1e-7a30-9c2d-1e6b8f5a3c09"
+          },
+          {
+            "type": "derives-from",
+            "target": "urn:uuid:0198b805-0f1e-7d2c-9b3a-a1b2c3d4e5f6"
+          }
+        ]
+      },
+      "hints": {
+        "relationships": [
+          "type",
+          "target"
+        ]
+      },
+      "expected_canonical": "{\"relationships\":[{\"target\":\"urn:uuid:0198b7d0-5b1e-7a30-9c2d-1e6b8f5a3c09\",\"type\":\"derives-from\"},{\"target\":\"urn:uuid:0198b805-0f1e-7d2c-9b3a-a1b2c3d4e5f6\",\"type\":\"derives-from\"},{\"target\":\"urn:uuid:0198b7d5-8c4a-7d22-a142-6b5e3c9f7011\",\"type\":\"satisfies\"}]}",
+      "expected_hash": "sha256:2e7107f828a9b2caf8cbae96250089eba25998e188237cd99f1d6de5e3d5fcd7"
+    },
+    {
+      "name": "ordered-array-preserved",
+      "kind": "canonical",
+      "input": {
+        "acceptance_criteria": [
+          "z-last-first",
+          "a-first-last"
+        ]
+      },
+      "hints": {},
+      "expected_canonical": "{\"acceptance_criteria\":[\"z-last-first\",\"a-first-last\"]}",
+      "expected_hash": "sha256:f67bf22df005cbbca91e6ed7d72bb2e62d38d4645e9534a3e2aca3cf8b23ba91"
+    },
+    {
+      "name": "null-vs-absent",
+      "kind": "canonical",
+      "input": {
+        "present": null
+      },
+      "hints": {},
+      "expected_canonical": "{\"present\":null}",
+      "expected_hash": "sha256:924c481da1aca4bbd856f20e4aaef20f67c34fccd0b5e27cb2647b8c45ee21ac"
+    },
+    {
+      "name": "key-ordering-jcs",
+      "kind": "canonical",
+      "input": {
+        "b": 1,
+        "a": 2,
+        "é": 3,
+        "Z": 4
+      },
+      "hints": {},
+      "expected_canonical": "{\"Z\":4,\"a\":2,\"b\":1,\"é\":3}",
+      "expected_hash": "sha256:f42490331d281d5684ce3ead1597c84179d3c711e721b413c9fef552265d56a0"
+    },
+    {
+      "name": "content-hash-governed-projection",
+      "kind": "content_hash",
+      "input": {
+        "schema_version": "rdlc.artifact/v0.2",
+        "id": "urn:uuid:0198b7e0-6a2f-7b41-8d3e-2f7c9a6b4d10",
+        "title": "Preserve an incomplete checkout",
+        "statement": "The checkout service shall preserve an incomplete checkout.",
+        "relationships": [
+          {
+            "type": "derives-from",
+            "target": "urn:uuid:0198b7d0-5b1e-7a30-9c2d-1e6b8f5a3c09"
+          }
+        ],
+        "display_id": "REQ-104",
+        "updated_at": "2026-08-15T16:12:00Z",
+        "unknown_extension": {
+          "vendor": "x"
+        }
+      },
+      "schema": {
+        "x-rdlc-governed": [
+          "title",
+          "statement",
+          "relationships"
+        ],
+        "x-rdlc-set-keys": {
+          "relationships": [
+            "type",
+            "target"
+          ]
+        }
+      },
+      "expected_hash": "sha256:40aa0b0abc8d0615c03ff2bfdb3cc4705829c671cb7c72e99fc580e5fb0c54bb"
+    },
+    {
+      "name": "content-hash-ignores-excluded-and-ungoverned",
+      "kind": "content_hash",
+      "input": {
+        "schema_version": "rdlc.artifact/v0.2",
+        "id": "urn:uuid:0198b7e0-6a2f-7b41-8d3e-2f7c9a6b4d10",
+        "title": "Preserve an incomplete checkout",
+        "statement": "The checkout service shall preserve an incomplete checkout.",
+        "relationships": [
+          {
+            "type": "derives-from",
+            "target": "urn:uuid:0198b7d0-5b1e-7a30-9c2d-1e6b8f5a3c09"
+          }
+        ],
+        "display_id": "REQ-999",
+        "updated_at": "2027-01-01T00:00:00Z",
+        "unknown_extension": {
+          "vendor": "y"
+        }
+      },
+      "schema": {
+        "x-rdlc-governed": [
+          "title",
+          "statement",
+          "relationships"
+        ],
+        "x-rdlc-set-keys": {
+          "relationships": [
+            "type",
+            "target"
+          ]
+        }
+      },
+      "expected_hash": "sha256:40aa0b0abc8d0615c03ff2bfdb3cc4705829c671cb7c72e99fc580e5fb0c54bb"
+    }
+  ]
+}

--- a/fixtures/canonical/kat.json
+++ b/fixtures/canonical/kat.json
@@ -21,8 +21,8 @@
         "fractional": "2026-08-15T17:02:00.250Z"
       },
       "hints": {},
-      "expected_canonical": "{\"already\":\"2026-08-15T17:02:00Z\",\"at\":\"2026-08-15T17:02:00Z\",\"fractional\":\"2026-08-15T17:02:00.250Z\"}",
-      "expected_hash": "sha256:49767fc5547e9f724b6f2c718d68d00a8c003ac870a5bdb89931c83a640d95a4"
+      "expected_canonical": "{\"already\":\"2026-08-15T17:02:00.000Z\",\"at\":\"2026-08-15T17:02:00.000Z\",\"fractional\":\"2026-08-15T17:02:00.250Z\"}",
+      "expected_hash": "sha256:424f63f6cd2b25c4a17a17d1b8ac8bc0077ad02d8e01411615be0e37b272179f"
     },
     {
       "name": "numeric-boundaries",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "canonicalize": "^4.0.0",
         "yaml": "2.9.0"
       },
       "devDependencies": {
@@ -33,6 +34,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/canonicalize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-4.0.0.tgz",
+      "integrity": "sha512-FEdXzwWs+N3rZqEqpqleiY9M1A6IAf9oo1zHFABnLW9FcJ/jzsu+G/Ks3Hq3FglmPKe80GeGBw8ZXLEnwPB0vQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "canonicalize": "^4.0.0",
+        "canonicalize": "4.0.0",
         "yaml": "2.9.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,13 @@
   "bugs": {
     "url": "https://github.com/aithinkers/requirements-dlc/issues"
   },
-  "keywords": ["requirements", "governance", "agents", "traceability", "lifecycle"],
+  "keywords": [
+    "requirements",
+    "governance",
+    "agents",
+    "traceability",
+    "lifecycle"
+  ],
   "type": "module",
   "engines": {
     "node": ">=22 <25"
@@ -24,6 +30,7 @@
     "test": "npm run check:governance && npm run test:governance"
   },
   "dependencies": {
+    "canonicalize": "^4.0.0",
     "yaml": "2.9.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test": "npm run check:governance && npm run test:governance"
   },
   "dependencies": {
-    "canonicalize": "^4.0.0",
+    "canonicalize": "4.0.0",
     "yaml": "2.9.0"
   },
   "devDependencies": {

--- a/tests/governance/canonical.test.mjs
+++ b/tests/governance/canonical.test.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  CanonicalizationError,
+  HASH_PROFILE_VERSION,
+  approvalPackageHash,
+  baselineRootHash,
+  canonicalBytes,
+  contentHash,
+  normalizeTimestamp,
+  parseStrict,
+  readbackHash,
+  redactionAddendumHash,
+  sourceHash
+} from "../../core/lib/canonical.mjs";
+
+const kat = JSON.parse(await readFile("fixtures/canonical/kat.json", "utf8"));
+
+test("FEAT-003: known-answer vectors reproduce exactly", () => {
+  assert.equal(kat.profile, HASH_PROFILE_VERSION);
+  assert.ok(kat.cases.length >= 9);
+  for (const entry of kat.cases) {
+    if (entry.kind === "canonical") {
+      const bytes = canonicalBytes(entry.input, entry.hints);
+      assert.equal(bytes.toString("utf8"), entry.expected_canonical, entry.name);
+      assert.equal(sourceHash(bytes).hash, entry.expected_hash, entry.name);
+    } else if (entry.kind === "content_hash") {
+      assert.equal(contentHash(entry.input, entry.schema).hash, entry.expected_hash, entry.name);
+    } else {
+      assert.fail(`unknown KAT kind: ${entry.kind}`);
+    }
+  }
+});
+
+test("FEAT-003: KAT coverage spans the §44.1 vector categories", () => {
+  const names = kat.cases.map(({ name }) => name).join(" ");
+  for (const required of ["unicode", "timestamp", "numeric", "set-like", "ordered", "null", "excluded"]) {
+    assert.match(names, new RegExp(required), `missing ${required} vector`);
+  }
+});
+
+test("FEAT-003: NFC normalization makes composed and decomposed strings hash-equal", () => {
+  const composed = canonicalBytes({ t: "café" });
+  const decomposed = canonicalBytes({ t: "café" });
+  assert.equal(composed.toString("utf8"), decomposed.toString("utf8"));
+});
+
+test("FEAT-003: timestamps normalize to UTC Z and reject non-instants", () => {
+  assert.equal(normalizeTimestamp("2026-08-15T19:02:00+02:00"), "2026-08-15T17:02:00Z");
+  assert.equal(normalizeTimestamp("2026-08-15T17:02:00.250Z"), "2026-08-15T17:02:00.250Z");
+  assert.throws(() => normalizeTimestamp("2026-08-15 17:02:00"), CanonicalizationError);
+});
+
+test("FEAT-003: duplicate object keys are rejected at parse time", () => {
+  assert.throws(() => parseStrict("a: 1\na: 2\n"), CanonicalizationError);
+  assert.throws(() => parseStrict('{"a":1,"a":2}'), CanonicalizationError);
+  assert.deepEqual(parseStrict('{"a":1}'), { a: 1 });
+});
+
+test("FEAT-003: non-I-JSON numbers fail closed", () => {
+  assert.throws(() => canonicalBytes({ n: Number.NaN }), CanonicalizationError);
+  assert.throws(() => canonicalBytes({ n: Number.POSITIVE_INFINITY }), CanonicalizationError);
+  assert.throws(() => canonicalBytes({ n: 9007199254740993 }), CanonicalizationError);
+});
+
+test("FEAT-003: set-like arrays sort by schema keys; ordered arrays preserve order", () => {
+  const sorted = canonicalBytes(
+    { r: [{ k: "b" }, { k: "a" }] },
+    { r: ["k"] }
+  ).toString("utf8");
+  assert.match(sorted, /"a".*"b"/s);
+  const ordered = canonicalBytes({ steps: ["b", "a"] }).toString("utf8");
+  assert.match(ordered, /"b","a"/);
+});
+
+test("FEAT-003: content hash excludes aliases, timestamps, and ungoverned unknown fields", () => {
+  const schema = { "x-rdlc-governed": ["title"], "x-rdlc-set-keys": {} };
+  const a = contentHash({ schema_version: "s/v1", id: "x", title: "T", display_id: "A-1", extra: 1 }, schema);
+  const b = contentHash({ schema_version: "s/v1", id: "x", title: "T", display_id: "B-9", extra: 2 }, schema);
+  const c = contentHash({ schema_version: "s/v1", id: "x", title: "Changed" }, schema);
+  assert.equal(a.hash, b.hash);
+  assert.notEqual(a.hash, c.hash);
+  assert.equal(a.hash_profile, HASH_PROFILE_VERSION);
+  assert.equal(a.schema_version, "s/v1");
+});
+
+test("FEAT-003: content hash fails closed without governed schema declarations", () => {
+  assert.throws(() => contentHash({ schema_version: "s/v1", id: "x" }, {}), CanonicalizationError);
+  assert.throws(() => contentHash({ id: "x" }, { "x-rdlc-governed": ["title"] }), CanonicalizationError);
+  assert.throws(
+    () => contentHash({ schema_version: "s/v1", id: "x" }, { "x-rdlc-governed": ["display_id"] }),
+    CanonicalizationError
+  );
+});
+
+test("FEAT-003: approval package hash excludes decisions and requires core inputs", () => {
+  const pkg = {
+    artifact_hashes: ["sha256:" + "a".repeat(64)],
+    policy_versions: ["approval-policy/v1"],
+    required_approvers: [{ principal: "urn:uuid:0198b7c0-2d5e-7f31-9a43-2c8e5b6a7012", role: "product-owner" }]
+  };
+  const first = approvalPackageHash(pkg);
+  assert.equal(first.profile, "approval_package_hash");
+  assert.throws(() => approvalPackageHash({ ...pkg, decisions: [] }), CanonicalizationError);
+  assert.throws(() => approvalPackageHash({ ...pkg, artifact_hashes: [] }), CanonicalizationError);
+});
+
+test("FEAT-003: baseline root and redaction addendum hashes are stable and fail closed", () => {
+  const manifest = {
+    approval_package_hashes: ["sha256:" + "b".repeat(64)],
+    artifact_hashes: ["sha256:" + "a".repeat(64)],
+    metadata: { baseline: "BL-1" }
+  };
+  const root = baselineRootHash(manifest);
+  assert.equal(root.hash, baselineRootHash({ ...manifest }).hash);
+  assert.throws(() => baselineRootHash({ artifact_hashes: [] }), CanonicalizationError);
+
+  const addendum = {
+    original_baseline_root: root.hash,
+    tombstones: [{ artifact: "urn:uuid:0198b7e0-6a2f-7b41-8d3e-2f7c9a6b4d10", original_hash: "sha256:" + "c".repeat(64) }],
+    authority: "privacy-office",
+    storage_boundary: "repository",
+    availability_state: "non-reconstructable"
+  };
+  const addendumHash = redactionAddendumHash(addendum);
+  assert.equal(addendumHash.profile, "redaction_addendum_hash");
+  assert.throws(() => redactionAddendumHash({ ...addendum, tombstones: [] }), CanonicalizationError);
+});
+
+test("FEAT-003: readback hash covers only mapped fields under a mapping version", () => {
+  const mapping = { version: "jira-commerce/v3", fields: ["summary", "status"] };
+  const a = readbackHash({ summary: "S", status: "To Do", unmapped: "x" }, mapping);
+  const b = readbackHash({ summary: "S", status: "To Do", unmapped: "y" }, mapping);
+  const c = readbackHash({ summary: "S", status: "Done" }, mapping);
+  assert.equal(a.hash, b.hash);
+  assert.notEqual(a.hash, c.hash);
+  assert.equal(a.mapping_version, "jira-commerce/v3");
+  assert.throws(() => readbackHash({}, { fields: [] }), CanonicalizationError);
+});
+
+test("FEAT-003: hashes are lowercase sha256:<64 hex> with profile versions attached", () => {
+  const record = sourceHash(Buffer.from("evidence"));
+  assert.match(record.hash, /^sha256:[0-9a-f]{64}$/);
+  assert.equal(record.hash_profile, HASH_PROFILE_VERSION);
+});

--- a/tests/governance/canonical.test.mjs
+++ b/tests/governance/canonical.test.mjs
@@ -47,10 +47,41 @@ test("FEAT-003: NFC normalization makes composed and decomposed strings hash-equ
   assert.equal(composed.toString("utf8"), decomposed.toString("utf8"));
 });
 
-test("FEAT-003: timestamps normalize to UTC Z and reject non-instants", () => {
-  assert.equal(normalizeTimestamp("2026-08-15T19:02:00+02:00"), "2026-08-15T17:02:00Z");
+test("FEAT-003: timestamp canonicalization is injective at millisecond precision", () => {
+  // One instant, many notations -> exactly one canonical form.
+  const canonical = "2026-08-15T17:02:00.000Z";
+  for (const notation of [
+    "2026-08-15T19:02:00+02:00",
+    "2026-08-15T17:02:00Z",
+    "2026-08-15T17:02:00.0Z",
+    "2026-08-15T17:02:00.000000Z",
+    "2026-08-15t17:02:00z"
+  ]) {
+    assert.equal(normalizeTimestamp(notation), canonical, notation);
+  }
   assert.equal(normalizeTimestamp("2026-08-15T17:02:00.250Z"), "2026-08-15T17:02:00.250Z");
+  assert.equal(normalizeTimestamp("2026-08-15T17:02:00.2500Z"), "2026-08-15T17:02:00.250Z");
+  // Informative sub-millisecond precision fails closed instead of truncating.
+  assert.throws(() => normalizeTimestamp("2026-08-15T17:02:00.123456Z"), CanonicalizationError);
   assert.throws(() => normalizeTimestamp("2026-08-15 17:02:00"), CanonicalizationError);
+});
+
+test("FEAT-003: object keys are NFC-normalized and collisions fail closed", () => {
+  const composedKey = "caf\u00e9";
+  const decomposedKey = "café";
+  const a = canonicalBytes({ [composedKey]: 1 }).toString("utf8");
+  const b = canonicalBytes({ [decomposedKey]: 1 }).toString("utf8");
+  assert.equal(a, b);
+  assert.throws(
+    () => canonicalBytes({ [composedKey]: 1, [decomposedKey]: 2 }),
+    CanonicalizationError
+  );
+});
+
+test("FEAT-003: set-sort ties break deterministically, independent of producer order", () => {
+  const forward = canonicalBytes({ r: [{ k: "a", v: 2 }, { k: "a", v: 1 }] }, { r: ["k"] }).toString("utf8");
+  const reversed = canonicalBytes({ r: [{ k: "a", v: 1 }, { k: "a", v: 2 }] }, { r: ["k"] }).toString("utf8");
+  assert.equal(forward, reversed);
 });
 
 test("FEAT-003: duplicate object keys are rejected at parse time", () => {

--- a/tests/governance/canonical.test.mjs
+++ b/tests/governance/canonical.test.mjs
@@ -76,6 +76,12 @@ test("FEAT-003: object keys are NFC-normalized and collisions fail closed", () =
     () => canonicalBytes({ [composedKey]: 1, [decomposedKey]: 2 }),
     CanonicalizationError
   );
+  // Two distinct non-NFC raw keys converging on one NFC key must also fail
+  // closed even when the composed form is absent from the source object.
+  assert.throws(
+    () => canonicalBytes({ "\u212B": "angstrom", "A\u030A": "a-ring" }),
+    CanonicalizationError
+  );
 });
 
 test("FEAT-003: set-sort ties break deterministically, independent of producer order", () => {


### PR DESCRIPTION
## Outcome

Implements the rdlc-jcs-v1 canonicalization profile and all six hash profiles (source, content, approval-package, baseline-root, redaction-addendum, read-back): RFC 8785 serialization over NFC-normalized, timestamp-normalized, schema-hint-sorted logical values; I-JSON number guards; duplicate-key rejection; fail-closed errors; and frozen known-answer vectors.

Closes #4

## Traceability

- Requirement IDs: FEAT-003
- Specification sections: §12.5, §12.6, §44.1 item 2
- Conformance modules affected: Core, Governed-Basic (foundations)
- Traceability index updated: yes — FEAT-003 verified

## Gate evidence

- [x] Feature/requirement definition is complete and linked.
- [x] Implementation plan received the required review (ADR-001 item 6: canonicalize + x-rdlc-* annotations).
- [x] Development stayed within issue scope.
- [x] Deterministic tests cover acceptance and failure criteria.
- [x] Final review considered correctness, security, and traceability.

Commands and results:

```text
npm test
> check:governance — Governance verified: 13 traceable requirements and 5 development gates.
> test:governance — 37 pass, 0 fail (9 frozen KAT vectors spanning Unicode/timestamps/numeric boundaries/set-like/ordered/null-vs-absent/excluded fields; fail-closed tests for NaN/Infinity/unsafe integers, duplicate keys, missing governed declarations, embedded decisions, empty manifests)
```

## Security, privacy, rights, and retention

All hash paths fail closed per §12.5; approval-package hashing rejects embedded decisions/signatures; redaction-addendum hashing excludes removed content by construction. New production dependency: canonicalize@4.0.0 (already trusted in knowledge-dlc).

## Compatibility, migration, and rollback

KAT vectors freeze the profile: any future canonicalization change must fail these tests and go through a profile-version bump. Rollback = revert.

## Release and documentation

Unblocks approval packages (FEAT-009), baselines, idempotency keys, and read-back verification (FEAT-010).
