### PR TITLE
feat: UUIDv7 identity and alias authority (#5) [FEAT-004]

### DIFF
--- a/core/lib/identity.mjs
+++ b/core/lib/identity.mjs
@@ -1,0 +1,218 @@
+/**
+ * UUIDv7 canonical identities and display-alias allocation (spec §12.1, §12.2).
+ *
+ * Any offline writer may mint a UUIDv7 without coordination; sequential
+ * display aliases are allocated by a lease-protected alias authority whose
+ * storage backend must provide atomic compare-and-swap (ADR-001 item 7).
+ * A UUIDv7's timestamp bits are never trusted chronology (§12.1, §12.6).
+ */
+
+import { randomBytes } from "node:crypto";
+
+export class IdentityError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "IdentityError";
+  }
+}
+
+const UUID_V7_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const URN_PREFIX = "urn:uuid:";
+
+/**
+ * Generate an RFC 9562 UUIDv7: 48-bit Unix-millisecond timestamp,
+ * version 7, RFC 4122 variant, 74 random bits (vendored per ADR-001 item 5).
+ */
+export function uuidv7(now = Date.now()) {
+  if (!Number.isInteger(now) || now < 0 || now > 2 ** 48 - 1) {
+    throw new IdentityError(`timestamp out of the UUIDv7 range: ${now}`);
+  }
+  const bytes = randomBytes(16);
+  bytes[0] = (now / 2 ** 40) & 0xff;
+  bytes[1] = (now / 2 ** 32) & 0xff;
+  bytes[2] = (now / 2 ** 24) & 0xff;
+  bytes[3] = (now / 2 ** 16) & 0xff;
+  bytes[4] = (now / 2 ** 8) & 0xff;
+  bytes[5] = now & 0xff;
+  bytes[6] = (bytes[6] & 0x0f) | 0x70; // version 7
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 10
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+export function isUuidv7(value) {
+  return typeof value === "string" && UUID_V7_PATTERN.test(value);
+}
+
+/** Mint a canonical UUID URN identity (§12.1). */
+export function mintIdentity(now) {
+  return `${URN_PREFIX}${uuidv7(now)}`;
+}
+
+export function isCanonicalIdentity(value) {
+  return typeof value === "string" && value.startsWith(URN_PREFIX) && isUuidv7(value.slice(URN_PREFIX.length));
+}
+
+export function parseUrn(urn) {
+  if (!isCanonicalIdentity(urn)) throw new IdentityError(`not a canonical UUIDv7 URN: ${urn}`);
+  return urn.slice(URN_PREFIX.length);
+}
+
+/**
+ * Extract the embedded millisecond timestamp. Named to make the trust
+ * boundary explicit: this value is producer-asserted wall clock and MUST NOT
+ * be used for causal ordering, approval time, or lease decisions (§12.6).
+ */
+export function untrustedTimestampMs(urn) {
+  const uuid = parseUrn(urn);
+  return Number.parseInt(uuid.slice(0, 8) + uuid.slice(9, 13), 16);
+}
+
+/**
+ * In-memory compare-and-swap backend. Production deployments use a
+ * distributed authority (GitHub API ref CAS per ADR-001 item 7); this
+ * backend provides the same atomic contract for tests and single-process use.
+ */
+export class InMemoryCasBackend {
+  #state = null;
+  #version = 0;
+
+  async read() {
+    return { state: this.#state, version: this.#version };
+  }
+
+  /** Atomically replace state only when the caller read the current version. */
+  async compareAndSwap(expectedVersion, nextState) {
+    if (expectedVersion !== this.#version) return false;
+    this.#state = nextState;
+    this.#version += 1;
+    return true;
+  }
+}
+
+const INITIAL_AUTHORITY_STATE = Object.freeze({ counters: {}, aliases: {}, history: [] });
+
+/**
+ * Lease-protected sequential alias authority (§12.2, §35.9).
+ *
+ * Aliases are display conveniences: allocation never changes a canonical
+ * UUID, duplicate proposals are reconciled by retaining the first binding
+ * and allocating the next sequential alias to the second artifact, and
+ * released aliases are never recycled inside the retention window.
+ */
+export class AliasAuthority {
+  #backend;
+  #now;
+
+  constructor(backend, { now = () => new Date().toISOString() } = {}) {
+    this.#backend = backend ?? new InMemoryCasBackend();
+    this.#now = now;
+  }
+
+  async #mutate(mutator) {
+    for (let attempt = 0; attempt < 5000; attempt += 1) {
+      const { state, version } = await this.#backend.read();
+      const current = state ?? INITIAL_AUTHORITY_STATE;
+      const next = structuredClone(current);
+      const result = mutator(next);
+      if (await this.#backend.compareAndSwap(version, next)) return result;
+    }
+    throw new IdentityError("alias authority contention: compare-and-swap retries exhausted");
+  }
+
+  static #assertPrefix(prefix) {
+    if (typeof prefix !== "string" || !/^[A-Z][A-Z0-9]*(-[A-Z]+)?$/.test(prefix)) {
+      throw new IdentityError(`invalid alias prefix: ${prefix}`);
+    }
+  }
+
+  /** Allocate the next sequential alias for an artifact identity. */
+  async allocate(prefix, artifactUrn) {
+    AliasAuthority.#assertPrefix(prefix);
+    if (!isCanonicalIdentity(artifactUrn)) throw new IdentityError(`not a canonical identity: ${artifactUrn}`);
+    return this.#mutate((state) => {
+      const existing = Object.entries(state.aliases).find(
+        ([, binding]) => binding.artifact === artifactUrn && binding.prefix === prefix && binding.status === "active"
+      );
+      if (existing) return existing[0];
+      const counter = (state.counters[prefix] ?? 0) + 1;
+      state.counters[prefix] = counter;
+      const alias = `${prefix}-${counter}`;
+      state.aliases[alias] = { artifact: artifactUrn, prefix, status: "active", effective_at: this.#now() };
+      state.history.push({ alias, artifact: artifactUrn, action: "allocated", at: this.#now() });
+      return alias;
+    });
+  }
+
+  /**
+   * Reconcile branch-proposed aliases (§12.2): the first proposal for an
+   * alias is retained; a competing proposal for the same alias keeps its
+   * canonical UUID and receives the next sequential alias instead.
+   */
+  async reconcileProposal(proposedAlias, artifactUrn) {
+    if (!isCanonicalIdentity(artifactUrn)) throw new IdentityError(`not a canonical identity: ${artifactUrn}`);
+    const match = proposedAlias.match(/^([A-Z][A-Z0-9]*(?:-[A-Z]+)?)-(\d+)$/);
+    if (!match) throw new IdentityError(`invalid proposed alias: ${proposedAlias}`);
+    const [, prefix, number] = match;
+    return this.#mutate((state) => {
+      const binding = state.aliases[proposedAlias];
+      if (binding && binding.artifact !== artifactUrn) {
+        const counter = Math.max(state.counters[prefix] ?? 0, Number(number)) + 1;
+        state.counters[prefix] = counter;
+        const alias = `${prefix}-${counter}`;
+        state.aliases[alias] = { artifact: artifactUrn, prefix, status: "active", effective_at: this.#now() };
+        state.history.push({ alias, artifact: artifactUrn, action: "reassigned-after-collision", proposed: proposedAlias, at: this.#now() });
+        return { alias, collided: true };
+      }
+      if (!binding) {
+        state.counters[prefix] = Math.max(state.counters[prefix] ?? 0, Number(number));
+        state.aliases[proposedAlias] = { artifact: artifactUrn, prefix, status: "active", effective_at: this.#now() };
+        state.history.push({ alias: proposedAlias, artifact: artifactUrn, action: "allocated", at: this.#now() });
+      }
+      return { alias: proposedAlias, collided: false };
+    });
+  }
+
+  /** Retire an alias when a new one supersedes it; history keeps both (§12.2). */
+  async supersede(alias, replacementAlias, artifactUrn) {
+    return this.#mutate((state) => {
+      const binding = state.aliases[alias];
+      if (!binding || binding.artifact !== artifactUrn) {
+        throw new IdentityError(`alias is not bound to the artifact: ${alias}`);
+      }
+      binding.status = "superseded";
+      binding.superseded_by = replacementAlias;
+      state.aliases[replacementAlias] = {
+        artifact: artifactUrn, prefix: binding.prefix, status: "active",
+        effective_at: this.#now(), previous: alias
+      };
+      state.history.push({ alias: replacementAlias, previous: alias, artifact: artifactUrn, action: "superseded", at: this.#now() });
+      return replacementAlias;
+    });
+  }
+
+  /**
+   * Resolve an alias (current or historical) to its canonical UUID URN;
+   * ambiguous or recycled aliases fail closed (§12.2).
+   */
+  async resolve(alias) {
+    const { state } = await this.#backend.read();
+    const current = state ?? INITIAL_AUTHORITY_STATE;
+    const binding = current.aliases[alias];
+    if (!binding) throw new IdentityError(`unknown alias: ${alias}`);
+    const boundArtifacts = new Set(
+      current.history.filter((entry) => entry.alias === alias).map((entry) => entry.artifact)
+    );
+    if (boundArtifacts.size > 1) throw new IdentityError(`ambiguous or recycled alias: ${alias}`);
+    return { id: binding.artifact, status: binding.status };
+  }
+
+  /** Full audit history for an alias or artifact. */
+  async history({ alias, artifact } = {}) {
+    const { state } = await this.#backend.read();
+    const current = state ?? INITIAL_AUTHORITY_STATE;
+    return current.history.filter(
+      (entry) => (alias === undefined || entry.alias === alias) && (artifact === undefined || entry.artifact === artifact)
+    );
+  }
+}

--- a/core/lib/identity.mjs
+++ b/core/lib/identity.mjs
@@ -175,10 +175,25 @@ export class AliasAuthority {
 
   /** Retire an alias when a new one supersedes it; history keeps both (§12.2). */
   async supersede(alias, replacementAlias, artifactUrn) {
+    if (typeof replacementAlias !== "string" || !/^[A-Z][A-Z0-9]*(-[A-Z0-9]+)*-?\d*$/.test(replacementAlias) || replacementAlias === alias) {
+      throw new IdentityError(`invalid replacement alias: ${replacementAlias}`);
+    }
     return this.#mutate((state) => {
       const binding = state.aliases[alias];
       if (!binding || binding.artifact !== artifactUrn) {
         throw new IdentityError(`alias is not bound to the artifact: ${alias}`);
+      }
+      if (binding.status !== "active") {
+        throw new IdentityError(`alias is not active and cannot be superseded: ${alias}`);
+      }
+      if (state.aliases[replacementAlias]) {
+        throw new IdentityError(`replacement alias is already bound: ${replacementAlias}`);
+      }
+      const numeric = replacementAlias.match(/^([A-Z][A-Z0-9]*(?:-[A-Z]+)?)-(\d+)$/);
+      if (numeric) {
+        // Reserve numeric replacements against the sequential counter so a
+        // later allocation can never recycle this alias (§12.2).
+        state.counters[numeric[1]] = Math.max(state.counters[numeric[1]] ?? 0, Number(numeric[2]));
       }
       binding.status = "superseded";
       binding.superseded_by = replacementAlias;

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -114,10 +114,14 @@
         "§12.2",
         "§35.9"
       ],
-      "status": "planned",
+      "status": "verified",
       "evidence": {
-        "implementation": [],
-        "tests": []
+        "implementation": [
+          "core/lib/identity.mjs"
+        ],
+        "tests": [
+          "tests/governance/identity.test.mjs"
+        ]
       }
     },
     {

--- a/tests/governance/identity.test.mjs
+++ b/tests/governance/identity.test.mjs
@@ -125,3 +125,20 @@ test("FEAT-004: a recycled alias is detected as ambiguous and fails closed", asy
   await backend.compareAndSwap(version, corrupted);
   await assert.rejects(authority.resolve("REQ-1"), /ambiguous or recycled/);
 });
+
+test("FEAT-004: supersede reserves numeric replacements and rejects rebinding (review findings)", async () => {
+  const authority = new AliasAuthority(new InMemoryCasBackend());
+  const p = mintIdentity();
+  const q = mintIdentity();
+  await authority.allocate("REQ", p); // REQ-1
+  await authority.supersede("REQ-1", "REQ-2", p);
+  // Counter must have advanced past the reserved replacement.
+  assert.equal(await authority.allocate("REQ", q), "REQ-3");
+  // An already-bound replacement is rejected, not clobbered.
+  await assert.rejects(authority.supersede("REQ-3", "REQ-2", q), /already bound/);
+  // A superseded alias cannot be superseded again.
+  await assert.rejects(authority.supersede("REQ-1", "REQ-9", p), /not active/);
+  // Format validation applies to replacements.
+  await assert.rejects(authority.supersede("REQ-3", "req-x", q), IdentityError);
+  await assert.rejects(authority.supersede("REQ-3", "REQ-3", q), IdentityError);
+});

--- a/tests/governance/identity.test.mjs
+++ b/tests/governance/identity.test.mjs
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  AliasAuthority,
+  IdentityError,
+  InMemoryCasBackend,
+  isCanonicalIdentity,
+  isUuidv7,
+  mintIdentity,
+  untrustedTimestampMs,
+  uuidv7
+} from "../../core/lib/identity.mjs";
+
+test("FEAT-004: generated identifiers validate as RFC 9562 UUIDv7", () => {
+  for (let i = 0; i < 500; i += 1) {
+    const value = uuidv7();
+    assert.ok(isUuidv7(value), value);
+    assert.equal(value[14], "7", "version nibble");
+    assert.ok("89ab".includes(value[19]), "variant nibble");
+  }
+});
+
+test("FEAT-004: minted identities are unique canonical URNs", () => {
+  const seen = new Set(Array.from({ length: 2000 }, () => mintIdentity()));
+  assert.equal(seen.size, 2000);
+  for (const urn of seen) assert.ok(isCanonicalIdentity(urn));
+});
+
+test("FEAT-004: the embedded timestamp is exposed only as untrusted metadata", () => {
+  const urn = mintIdentity(1755277320000);
+  assert.equal(untrustedTimestampMs(urn), 1755277320000);
+  // The API name is the contract: no trusted-chronology accessor exists.
+  const identity = await_import_names();
+  assert.ok(!identity.includes("trustedTimestamp"));
+  assert.ok(identity.includes("untrustedTimestampMs"));
+});
+
+function await_import_names() {
+  return Object.keys({
+    AliasAuthority, IdentityError, InMemoryCasBackend, isCanonicalIdentity,
+    isUuidv7, mintIdentity, untrustedTimestampMs, uuidv7
+  });
+}
+
+test("FEAT-004: uuidv7 rejects out-of-range timestamps", () => {
+  assert.throws(() => uuidv7(-1), IdentityError);
+  assert.throws(() => uuidv7(2 ** 48), IdentityError);
+  assert.throws(() => uuidv7(1.5), IdentityError);
+});
+
+test("FEAT-004: sequential aliases allocate per prefix and are idempotent per artifact", async () => {
+  const authority = new AliasAuthority(new InMemoryCasBackend());
+  const a = mintIdentity();
+  const b = mintIdentity();
+  assert.equal(await authority.allocate("REQ", a), "REQ-1");
+  assert.equal(await authority.allocate("REQ", b), "REQ-2");
+  assert.equal(await authority.allocate("REQ", a), "REQ-1", "re-allocation is idempotent");
+  assert.equal(await authority.allocate("RISK", b), "RISK-1", "counters are per prefix");
+  await assert.rejects(authority.allocate("req", a), IdentityError);
+  await assert.rejects(authority.allocate("REQ", "REQ-104"), IdentityError);
+});
+
+test("FEAT-004: colliding branch proposals reconcile without changing canonical UUIDs (§12.2)", async () => {
+  const authority = new AliasAuthority(new InMemoryCasBackend());
+  const first = mintIdentity();
+  const second = mintIdentity();
+  const kept = await authority.reconcileProposal("REQ-104", first);
+  assert.deepEqual(kept, { alias: "REQ-104", collided: false });
+  const reassigned = await authority.reconcileProposal("REQ-104", second);
+  assert.equal(reassigned.collided, true);
+  assert.equal(reassigned.alias, "REQ-105");
+  assert.equal((await authority.resolve("REQ-104")).id, first);
+  assert.equal((await authority.resolve("REQ-105")).id, second);
+});
+
+test("FEAT-004: alias history retains previous aliases and effective dates (§12.2)", async () => {
+  let tick = 0;
+  const authority = new AliasAuthority(new InMemoryCasBackend(), {
+    now: () => `2026-08-15T19:00:0${tick++}.000Z`
+  });
+  const artifact = mintIdentity();
+  const alias = await authority.allocate("REQ", artifact);
+  await authority.supersede(alias, "REQ-CHECKOUT-1", artifact);
+  const history = await authority.history({ artifact });
+  assert.equal(history.length, 2);
+  assert.equal(history[0].action, "allocated");
+  assert.equal(history[1].action, "superseded");
+  assert.equal(history[1].previous, "REQ-1");
+  assert.ok(history.every((entry) => /^2026-08-15T19:00:0\dZ?/.test(entry.at) || entry.at.endsWith("Z")));
+  const resolved = await authority.resolve("REQ-1");
+  assert.deepEqual(resolved, { id: artifact, status: "superseded" });
+  assert.equal((await authority.resolve("REQ-CHECKOUT-1")).status, "active");
+});
+
+test("FEAT-004: superseding an alias not bound to the artifact fails closed", async () => {
+  const authority = new AliasAuthority(new InMemoryCasBackend());
+  const artifact = mintIdentity();
+  await authority.allocate("REQ", artifact);
+  await assert.rejects(authority.supersede("REQ-1", "REQ-2", mintIdentity()), IdentityError);
+  await assert.rejects(authority.resolve("REQ-999"), IdentityError);
+});
+
+test("FEAT-004: concurrent allocations serialize through compare-and-swap without duplicates", async () => {
+  const authority = new AliasAuthority(new InMemoryCasBackend());
+  const aliases = await Promise.all(
+    Array.from({ length: 100 }, () => authority.allocate("STORY", mintIdentity()))
+  );
+  assert.equal(new Set(aliases).size, 100);
+  const numbers = aliases.map((alias) => Number(alias.split("-")[1])).sort((x, y) => x - y);
+  assert.deepEqual(numbers, Array.from({ length: 100 }, (_, i) => i + 1));
+});
+
+test("FEAT-004: a recycled alias is detected as ambiguous and fails closed", async () => {
+  const backend = new InMemoryCasBackend();
+  const authority = new AliasAuthority(backend);
+  const first = mintIdentity();
+  const second = mintIdentity();
+  await authority.allocate("REQ", first);
+  // Simulate an unauthorized manual recycle in the underlying state.
+  const { state, version } = await backend.read();
+  const corrupted = structuredClone(state);
+  corrupted.aliases["REQ-1"] = { artifact: second, prefix: "REQ", status: "active", effective_at: "2027-01-01T00:00:00.000Z" };
+  corrupted.history.push({ alias: "REQ-1", artifact: second, action: "allocated", at: "2027-01-01T00:00:00.000Z" });
+  await backend.compareAndSwap(version, corrupted);
+  await assert.rejects(authority.resolve("REQ-1"), /ambiguous or recycled/);
+});


### PR DESCRIPTION
## Outcome

Implements canonical UUIDv7 identity (vendored RFC 9562 generator per ADR-001 item 5) and the lease-protected sequential display-alias authority: idempotent per-artifact allocation, branch-collision reconciliation that never changes canonical UUIDs, alias supersession with retained history and effective dates, ambiguous/recycled-alias fail-closed resolution, and an atomic compare-and-swap backend contract (in-memory reference; GitHub ref CAS lands with FEAT-008 per ADR-001 item 7).

Closes #5

## Traceability

- Requirement IDs: FEAT-004
- Specification sections: §12.1, §12.2, §12.6, §35.9
- Conformance modules affected: Core
- Traceability index updated: yes — FEAT-004 verified

## Gate evidence

- [x] Feature/requirement definition is complete and linked.
- [x] Implementation plan received the required review (ADR-001 items 5 and 7).
- [x] Development stayed within issue scope.
- [x] Deterministic tests cover acceptance and failure criteria.
- [x] Final review considered correctness, security, and traceability.

Commands and results:

```text
npm test
> check:governance — Governance verified: 13 traceable requirements and 5 development gates.
> test:governance — 49 pass, 0 fail (500 generated v7 IDs validate version/variant bits; 2000 unique URNs; collision reconciliation preserves UUIDs; alias history and supersession; 100 concurrent CAS allocations without duplicates; recycled-alias ambiguity fails closed; out-of-range timestamps rejected)
```

## Security, privacy, rights, and retention

The embedded UUIDv7 timestamp is exposed only as `untrustedTimestampMs` — no trusted-chronology accessor exists (§12.6). Alias mutations require the CAS authority; contention exhaustion fails closed rather than double-allocating.

## Compatibility, migration, and rollback

Additive library; alias-authority state schema is internal until FEAT-008 externalizes it into collaboration/ records. Rollback = revert.

## Release and documentation

Unblocks promotion-time alias allocation (FEAT-006) and lease-serialized mutations (FEAT-008).
