### PR TITLE
feat: identity registry, approvals, baselines, redaction (#10) [FEAT-009]

### DIFF
--- a/core/lib/approval.mjs
+++ b/core/lib/approval.mjs
@@ -162,7 +162,7 @@ export function recordDecision(registry, {
   }
   const { principal, binding } = registry.resolveAccount({ provider, connection, accountId });
   if (principal.status !== "active") throw new ApprovalError(`principal is not active: ${principal.id}`);
-  if (role && principal.kind === "human" && principal.roles.length > 0 && !principal.roles.includes(role)) {
+  if (role && principal.kind === "human" && !principal.roles.includes(role)) {
     throw new ApprovalError(`principal does not hold role ${role} (§27.3 separation of duties)`);
   }
   const record = {
@@ -239,11 +239,19 @@ export function evaluatePolicy(policy, decisions, { packageHash, registry }) {
     const missing = policy.roles.filter((role) => (byRole.get(role)?.size ?? 0) === 0);
     if (policy.separationOfDuties) {
       // §27.3 — each required role must be satisfied by a DISTINCT principal.
-      const used = new Set();
-      for (const role of policy.roles) {
-        const candidate = [...(byRole.get(role) ?? [])].find((principal) => !used.has(principal));
-        if (!candidate) return { satisfied: false, missing: [role], reason: "separation of duties requires distinct principals" };
-        used.add(candidate);
+      // Backtracking assignment so a valid matching is never missed by order.
+      const assign = (index, used) => {
+        if (index === policy.roles.length) return true;
+        for (const principal of byRole.get(policy.roles[index]) ?? []) {
+          if (used.has(principal)) continue;
+          used.add(principal);
+          if (assign(index + 1, used)) return true;
+          used.delete(principal);
+        }
+        return false;
+      };
+      if (!assign(0, new Set())) {
+        return { satisfied: false, missing: [...policy.roles], reason: "separation of duties requires distinct principals" };
       }
     }
     return { satisfied: missing.length === 0, missing };

--- a/core/lib/approval.mjs
+++ b/core/lib/approval.mjs
@@ -6,6 +6,10 @@
  * identities, shared/automation accounts in human roles, stale hashes, and
  * unknown accounts never satisfy policy. Baselines are immutable; redaction
  * preserves tombstones and original hashes without rewriting history.
+ *
+ * Deferred from this slice (§27.3): sequential ordering, delegation, groups,
+ * timeout/reminder/escalation, and advisory-only review — tracked for the
+ * readiness/engagement layer. Change invalidation lives in lifecycle.mjs.
  */
 
 import {
@@ -16,6 +20,14 @@ import {
   sourceHash
 } from "./canonical.mjs";
 import { isCanonicalIdentity, mintIdentity } from "./identity.mjs";
+
+function deepFreeze(value) {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const entry of Object.values(value)) deepFreeze(entry);
+  }
+  return value;
+}
 
 export class ApprovalError extends Error {
   constructor(message) {
@@ -62,6 +74,13 @@ export class IdentityRegistry {
     }
     if (!isCanonicalIdentity(verifiedBy)) throw new ApprovalError("a binding requires a canonical verifier");
     if (!verifiedAt) throw new ApprovalError("a binding requires a verification time");
+    // §27.2 — one provider account binds to exactly one canonical principal.
+    for (const other of this.#principals.values()) {
+      if (other.bindings.some((entry) => entry.provider === provider && entry.connection === connection
+        && entry.account_id === accountId && entry.status === "verified")) {
+        throw new ApprovalError(`provider account is already bound to principal ${other.id} (§27.2)`);
+      }
+    }
     const binding = {
       provider, connection, tenant_id: tenantId ?? null, account_id: accountId,
       verified_via: verifiedVia, verified_by: verifiedBy, verified_at: verifiedAt, status: "verified"
@@ -143,6 +162,9 @@ export function recordDecision(registry, {
   }
   const { principal, binding } = registry.resolveAccount({ provider, connection, accountId });
   if (principal.status !== "active") throw new ApprovalError(`principal is not active: ${principal.id}`);
+  if (role && principal.kind === "human" && principal.roles.length > 0 && !principal.roles.includes(role)) {
+    throw new ApprovalError(`principal does not hold role ${role} (§27.3 separation of duties)`);
+  }
   const record = {
     schema_version: "rdlc.approval-decision/v0.2",
     id: mintIdentity(),
@@ -160,6 +182,17 @@ export function recordDecision(registry, {
   return Object.freeze(record);
 }
 
+/** Recompute and verify a decision record's integrity hash (§27.4). */
+export function verifyDecision(record) {
+  if (!record?.decision_hash) return false;
+  const { decision_hash, ...body } = record;
+  try {
+    return sourceHash(canonicalBytes({ ...body, decision_hash: undefined })).hash === decision_hash;
+  } catch {
+    return false;
+  }
+}
+
 /* --------------------------------------------------------- approval policies */
 
 /**
@@ -170,8 +203,15 @@ export function recordDecision(registry, {
 export function evaluatePolicy(policy, decisions, { packageHash, registry }) {
   const relevant = decisions.filter((entry) => entry.package_hash === packageHash);
   for (const entry of relevant) {
+    // §27.4 — only integrity-verified decision records count toward policy.
+    if (!verifyDecision(entry)) {
+      throw new ApprovalError(`decision record fails integrity verification: ${entry.id ?? "<unidentified>"}`);
+    }
     const principal = registry.get(entry.principal);
-    if (principal.kind !== "human" && !policy.automationRoles?.includes(entry.role)) {
+    if (principal.kind !== entry.principal_kind) {
+      throw new ApprovalError(`decision principal kind does not match the registry: ${entry.principal}`);
+    }
+    if (principal.kind !== "human" && entry.decision === "approve" && !policy.automationRoles?.includes(entry.role)) {
       throw new ApprovalError(`a non-human principal cannot satisfy human role ${entry.role} (§27.2)`);
     }
   }
@@ -191,8 +231,21 @@ export function evaluatePolicy(policy, decisions, { packageHash, registry }) {
     return { satisfied: count >= policy.quorum, count, quorum: policy.quorum };
   }
   if (policy.kind === "one-per-role") {
-    const rolesSatisfied = new Set(approvals.map((entry) => entry.role));
-    const missing = policy.roles.filter((role) => !rolesSatisfied.has(role));
+    const byRole = new Map();
+    for (const entry of approvals) {
+      if (!byRole.has(entry.role)) byRole.set(entry.role, new Set());
+      byRole.get(entry.role).add(entry.principal);
+    }
+    const missing = policy.roles.filter((role) => (byRole.get(role)?.size ?? 0) === 0);
+    if (policy.separationOfDuties) {
+      // §27.3 — each required role must be satisfied by a DISTINCT principal.
+      const used = new Set();
+      for (const role of policy.roles) {
+        const candidate = [...(byRole.get(role) ?? [])].find((principal) => !used.has(principal));
+        if (!candidate) return { satisfied: false, missing: [role], reason: "separation of duties requires distinct principals" };
+        used.add(candidate);
+      }
+    }
     return { satisfied: missing.length === 0, missing };
   }
   throw new ApprovalError(`unknown approval policy kind: ${policy.kind}`);
@@ -238,14 +291,14 @@ export function createBaseline({ packages, artifactHashes, sourceLocks = [], tom
     adopted_redaction_tombstones: tombstones,
     metadata
   });
-  return Object.freeze({
+  return deepFreeze({
     schema_version: "rdlc.baseline/v0.2",
     id: mintIdentity(),
-    approval_package_hashes: Object.freeze(packages.map((entry) => entry.package_hash)),
-    artifact_hashes: Object.freeze([...artifactHashes]),
-    source_locks: Object.freeze([...sourceLocks]),
-    adopted_redaction_tombstones: Object.freeze([...tombstones]),
-    metadata: Object.freeze({ ...metadata }),
+    approval_package_hashes: packages.map((entry) => entry.package_hash),
+    artifact_hashes: structuredClone([...artifactHashes]),
+    source_locks: structuredClone([...sourceLocks]),
+    adopted_redaction_tombstones: structuredClone([...tombstones]),
+    metadata: structuredClone({ ...metadata }),
     baseline_root_hash: root.hash,
     availability_state: "reconstructable"
   });
@@ -283,9 +336,16 @@ export function createTombstone({
  */
 export function applyRedaction(baseline, { tombstones, authority, storageBoundary, nonReconstructable = false, exceptions = [] }) {
   if (!Array.isArray(tombstones) || tombstones.length === 0) throw new ApprovalError("redaction requires tombstones");
+  for (const entry of tombstones) {
+    if (entry.affected_baseline !== baseline.baseline_root_hash) {
+      throw new ApprovalError(`tombstone ${entry.id} was minted against a different baseline (§41.1)`);
+    }
+  }
   const addendumBody = {
     original_baseline_root: baseline.baseline_root_hash,
-    tombstones: tombstones.map((entry) => ({ id: entry.id, artifact: entry.artifact, original_content_hash: entry.original_content_hash })),
+    tombstones: tombstones
+      .map((entry) => ({ id: entry.id, artifact: entry.artifact, original_content_hash: entry.original_content_hash }))
+      .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0)),
     authority,
     storage_boundary: storageBoundary,
     availability_state: nonReconstructable ? "non-reconstructable" : "redacted"

--- a/core/lib/approval.mjs
+++ b/core/lib/approval.mjs
@@ -1,0 +1,305 @@
+/**
+ * Identity registry, approvals, baselines, and redaction (spec §27, §41.1).
+ *
+ * Approval decisions bind a canonical principal through a VERIFIED provider
+ * binding to the exact rdlc-jcs-v1 approval-package hash. Unverified
+ * identities, shared/automation accounts in human roles, stale hashes, and
+ * unknown accounts never satisfy policy. Baselines are immutable; redaction
+ * preserves tombstones and original hashes without rewriting history.
+ */
+
+import {
+  approvalPackageHash,
+  baselineRootHash,
+  canonicalBytes,
+  redactionAddendumHash,
+  sourceHash
+} from "./canonical.mjs";
+import { isCanonicalIdentity, mintIdentity } from "./identity.mjs";
+
+export class ApprovalError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "ApprovalError";
+  }
+}
+
+const VERIFICATION_METHODS = Object.freeze([
+  "authenticated-self-binding", "directory-synchronization", "administrator-attestation"
+]);
+
+/* -------------------------------------------------------- identity registry */
+
+/** §27.2 — canonical principals with verified provider bindings. */
+export class IdentityRegistry {
+  #principals = new Map();
+
+  registerPrincipal({ id = mintIdentity(), displayName, kind, roles = [] }) {
+    if (!isCanonicalIdentity(id)) throw new ApprovalError("a principal requires a canonical identity");
+    if (!displayName) throw new ApprovalError("a principal requires a display name");
+    if (!["human", "automation"].includes(kind)) throw new ApprovalError(`unknown principal kind: ${kind}`);
+    const principal = { schema_version: "rdlc.principal/v0.2", id, display_name: displayName, kind, status: "active", roles: [...roles], bindings: [] };
+    this.#principals.set(id, principal);
+    return principal;
+  }
+
+  get(id) {
+    const principal = this.#principals.get(id);
+    if (!principal) throw new ApprovalError(`unknown principal: ${id}`);
+    return principal;
+  }
+
+  /**
+   * §27.2 — a binding is verified only through an accepted method; a manually
+   * entered email or display-name match is unverified and never satisfies a
+   * required human approval.
+   */
+  addBinding(principalId, { provider, connection, tenantId, accountId, verifiedVia, verifiedBy, verifiedAt }) {
+    const principal = this.get(principalId);
+    if (!provider || !connection || !accountId) throw new ApprovalError("a binding requires provider, connection, and immutable account id");
+    if (!VERIFICATION_METHODS.includes(verifiedVia)) {
+      throw new ApprovalError(`unaccepted verification method: ${verifiedVia} (manual matches are unverified, §27.2)`);
+    }
+    if (!isCanonicalIdentity(verifiedBy)) throw new ApprovalError("a binding requires a canonical verifier");
+    if (!verifiedAt) throw new ApprovalError("a binding requires a verification time");
+    const binding = {
+      provider, connection, tenant_id: tenantId ?? null, account_id: accountId,
+      verified_via: verifiedVia, verified_by: verifiedBy, verified_at: verifiedAt, status: "verified"
+    };
+    principal.bindings.push(binding);
+    return binding;
+  }
+
+  /** Revocation prevents future decisions but never erases history (§27.2). */
+  revokeBinding(principalId, accountId, { at }) {
+    const principal = this.get(principalId);
+    const binding = principal.bindings.find((entry) => entry.account_id === accountId && entry.status === "verified");
+    if (!binding) throw new ApprovalError(`no verified binding for account: ${accountId}`);
+    binding.status = "revoked";
+    binding.revoked_at = at;
+    return binding;
+  }
+
+  /** Resolve an authenticated provider account to its bound principal. */
+  resolveAccount({ provider, connection, accountId }) {
+    for (const principal of this.#principals.values()) {
+      const binding = principal.bindings.find(
+        (entry) => entry.provider === provider && entry.connection === connection
+          && entry.account_id === accountId && entry.status === "verified"
+      );
+      if (binding) return { principal, binding };
+    }
+    throw new ApprovalError(`no verified binding resolves ${provider}/${connection}/${accountId} (§27.2)`);
+  }
+}
+
+/* -------------------------------------------------------- approval packages */
+
+/** §27.4 — immutable, reproducible approval package with rdlc-jcs-v1 hash. */
+export function buildApprovalPackage({
+  artifactHashes, sourceLocks = [], kbLock = null, policyVersions, requiredApprovers,
+  blockingFindings = [], waivers = [], materialDiff = null
+}) {
+  const projection = {
+    artifact_hashes: artifactHashes,
+    source_locks: sourceLocks,
+    kb_lock: kbLock,
+    policy_versions: policyVersions,
+    required_approvers: requiredApprovers,
+    blocking_findings: blockingFindings,
+    waivers,
+    material_diff: materialDiff
+  };
+  const hashed = approvalPackageHash({
+    artifact_hashes: artifactHashes, source_locks: sourceLocks, kb_lock: kbLock,
+    policy_versions: policyVersions, required_approvers: requiredApprovers,
+    blocking_findings: blockingFindings, waivers, material_diff: materialDiff
+  });
+  return Object.freeze({
+    schema_version: "rdlc.approval-package/v0.2",
+    id: mintIdentity(),
+    ...projection,
+    package_hash: hashed.hash,
+    hash_profile: hashed.hash_profile
+  });
+}
+
+/* ------------------------------------------------------- approval decisions */
+
+/**
+ * §27.4 — a decision binds the canonical principal, its verified binding (or
+ * authenticated local identity), the decision, and the exact package hash.
+ */
+export function recordDecision(registry, {
+  provider, connection, accountId, decision, packageHash, expectedPackageHash, role, comment = null,
+  authenticationContext, at
+}) {
+  if (!["approve", "reject", "abstain"].includes(decision)) throw new ApprovalError(`unknown decision: ${decision}`);
+  if (!authenticationContext) throw new ApprovalError("a decision requires its authentication context (§27.4)");
+  if (!at) throw new ApprovalError("a decision requires a timestamp (informative metadata, §27.4)");
+  // §27.6/§46 step 8 — a decision against a stale or mismatched hash is rejected.
+  if (!packageHash || packageHash !== expectedPackageHash) {
+    throw new ApprovalError(`decision hash does not match the open approval package: ${packageHash} != ${expectedPackageHash}`);
+  }
+  const { principal, binding } = registry.resolveAccount({ provider, connection, accountId });
+  if (principal.status !== "active") throw new ApprovalError(`principal is not active: ${principal.id}`);
+  const record = {
+    schema_version: "rdlc.approval-decision/v0.2",
+    id: mintIdentity(),
+    principal: principal.id,
+    principal_kind: principal.kind,
+    binding: { provider, connection, account_id: accountId },
+    decision,
+    package_hash: packageHash,
+    role,
+    comment,
+    authentication_context: authenticationContext,
+    at
+  };
+  record.decision_hash = sourceHash(canonicalBytes({ ...record, decision_hash: undefined })).hash;
+  return Object.freeze(record);
+}
+
+/* --------------------------------------------------------- approval policies */
+
+/**
+ * §27.3 — evaluate a policy against recorded decisions for one package hash.
+ * Supported: all-required, n-of-m, one-per-role. Human roles are satisfied
+ * only by human principals (§27.2: no shared or service accounts).
+ */
+export function evaluatePolicy(policy, decisions, { packageHash, registry }) {
+  const relevant = decisions.filter((entry) => entry.package_hash === packageHash);
+  for (const entry of relevant) {
+    const principal = registry.get(entry.principal);
+    if (principal.kind !== "human" && !policy.automationRoles?.includes(entry.role)) {
+      throw new ApprovalError(`a non-human principal cannot satisfy human role ${entry.role} (§27.2)`);
+    }
+  }
+  const approvals = relevant.filter((entry) => entry.decision === "approve");
+  const declines = relevant.filter((entry) => entry.decision === "reject");
+  if (policy.declineBehavior !== "tolerate" && declines.length > 0) {
+    return { satisfied: false, reason: `declined by ${declines[0].principal}` };
+  }
+  if (policy.kind === "all-required") {
+    const approvedBy = new Set(approvals.map((entry) => entry.principal));
+    const missing = policy.required.filter((principal) => !approvedBy.has(principal));
+    return { satisfied: missing.length === 0, missing };
+  }
+  if (policy.kind === "n-of-m") {
+    const eligible = new Set(policy.eligible);
+    const count = new Set(approvals.filter((entry) => eligible.has(entry.principal)).map((entry) => entry.principal)).size;
+    return { satisfied: count >= policy.quorum, count, quorum: policy.quorum };
+  }
+  if (policy.kind === "one-per-role") {
+    const rolesSatisfied = new Set(approvals.map((entry) => entry.role));
+    const missing = policy.roles.filter((role) => !rolesSatisfied.has(role));
+    return { satisfied: missing.length === 0, missing };
+  }
+  throw new ApprovalError(`unknown approval policy kind: ${policy.kind}`);
+}
+
+/* ---------------------------------------------------------------- readiness */
+
+/** §27.5 — readiness conditions for entering ready-for-approval. */
+export function readinessCheck({
+  templatesPass, blockingFindings = [], waivers = [], evidenceLinks = [], materialCommentsOpen = 0,
+  dependencyCycles = [], approverSet = [], registry, reproduciblePackage
+}) {
+  const failures = [];
+  if (!templatesPass) failures.push("required templates do not pass");
+  const unwaived = blockingFindings.filter((finding) => !waivers.some((waiver) => waiver.finding === finding.id && waiver.valid));
+  if (unwaived.length > 0) failures.push(`blocking findings unresolved: ${unwaived.length}`);
+  if (evidenceLinks.length === 0) failures.push("required evidence and trace links are missing");
+  if (materialCommentsOpen > 0) failures.push(`material comments not dispositioned: ${materialCommentsOpen}`);
+  if (dependencyCycles.length > 0) failures.push("hard dependency cycles unresolved");
+  for (const approver of approverSet) {
+    try {
+      const principal = registry.get(approver);
+      if (principal.status !== "active" || !principal.bindings.some((binding) => binding.status === "verified")) {
+        failures.push(`approver lacks a verified identity: ${approver}`);
+      }
+    } catch {
+      failures.push(`approver cannot be resolved: ${approver}`);
+    }
+  }
+  if (!reproduciblePackage) failures.push("approval package is not reproducible");
+  return { ready: failures.length === 0, failures };
+}
+
+/* ---------------------------------------------------------------- baselines */
+
+/** §14.1/§27.5 — an immutable baseline over approved packages. */
+export function createBaseline({ packages, artifactHashes, sourceLocks = [], tombstones = [], metadata = {} }) {
+  if (!Array.isArray(packages) || packages.length === 0) throw new ApprovalError("a baseline requires approved packages");
+  const root = baselineRootHash({
+    approval_package_hashes: packages.map((entry) => entry.package_hash),
+    artifact_hashes: artifactHashes,
+    source_locks: sourceLocks,
+    adopted_redaction_tombstones: tombstones,
+    metadata
+  });
+  return Object.freeze({
+    schema_version: "rdlc.baseline/v0.2",
+    id: mintIdentity(),
+    approval_package_hashes: Object.freeze(packages.map((entry) => entry.package_hash)),
+    artifact_hashes: Object.freeze([...artifactHashes]),
+    source_locks: Object.freeze([...sourceLocks]),
+    adopted_redaction_tombstones: Object.freeze([...tombstones]),
+    metadata: Object.freeze({ ...metadata }),
+    baseline_root_hash: root.hash,
+    availability_state: "reconstructable"
+  });
+}
+
+/* ---------------------------------------------------------------- redaction */
+
+/** §41.1 — a tombstone excludes the removed content while keeping its hash. */
+export function createTombstone({
+  artifact, originalContentHash, affectedPackage, affectedBaseline, actor, authority, scope, reasonCode, decisionAt, replacementHash = null, content
+}) {
+  if (content !== undefined) throw new ApprovalError("a tombstone must exclude the content being removed (§41.1)");
+  for (const [field, value] of Object.entries({ artifact, originalContentHash, affectedPackage, affectedBaseline, actor, authority, scope, reasonCode, decisionAt })) {
+    if (!value) throw new ApprovalError(`a tombstone requires ${field}`);
+  }
+  return Object.freeze({
+    schema_version: "rdlc.redaction-tombstone/v0.2",
+    id: mintIdentity(),
+    artifact,
+    original_content_hash: originalContentHash,
+    affected_package: affectedPackage,
+    affected_baseline: affectedBaseline,
+    actor,
+    authority,
+    scope,
+    reason_code: reasonCode,
+    decision_at: decisionAt,
+    replacement_hash: replacementHash
+  });
+}
+
+/**
+ * §41.1 — an append-only addendum projects the original baseline as redacted
+ * (and optionally non-reconstructable) WITHOUT modifying its hashed manifest.
+ */
+export function applyRedaction(baseline, { tombstones, authority, storageBoundary, nonReconstructable = false, exceptions = [] }) {
+  if (!Array.isArray(tombstones) || tombstones.length === 0) throw new ApprovalError("redaction requires tombstones");
+  const addendumBody = {
+    original_baseline_root: baseline.baseline_root_hash,
+    tombstones: tombstones.map((entry) => ({ id: entry.id, artifact: entry.artifact, original_content_hash: entry.original_content_hash })),
+    authority,
+    storage_boundary: storageBoundary,
+    availability_state: nonReconstructable ? "non-reconstructable" : "redacted"
+  };
+  const hashed = redactionAddendumHash(addendumBody);
+  return {
+    baseline,
+    addendum: Object.freeze({
+      schema_version: "rdlc.redaction-addendum/v0.2",
+      id: mintIdentity(),
+      ...addendumBody,
+      deletion_exceptions: Object.freeze([...exceptions]),
+      addendum_hash: hashed.hash
+    }),
+    projected_state: addendumBody.availability_state
+  };
+}

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -209,10 +209,14 @@
         "§27",
         "§41.1"
       ],
-      "status": "planned",
+      "status": "verified",
       "evidence": {
-        "implementation": [],
-        "tests": []
+        "implementation": [
+          "core/lib/approval.mjs"
+        ],
+        "tests": [
+          "tests/governance/approval.test.mjs"
+        ]
       }
     },
     {

--- a/tests/governance/approval.test.mjs
+++ b/tests/governance/approval.test.mjs
@@ -1,0 +1,233 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ApprovalError,
+  IdentityRegistry,
+  applyRedaction,
+  buildApprovalPackage,
+  createBaseline,
+  createTombstone,
+  evaluatePolicy,
+  readinessCheck,
+  recordDecision
+} from "../../core/lib/approval.mjs";
+import { mintIdentity } from "../../core/lib/identity.mjs";
+
+const H = (c) => "sha256:" + c.repeat(64);
+
+function registryWith() {
+  const registry = new IdentityRegistry();
+  const alex = registry.registerPrincipal({ displayName: "Alex Morgan", kind: "human", roles: ["product-owner"] });
+  const sam = registry.registerPrincipal({ displayName: "Sam Lee", kind: "human", roles: ["compliance"] });
+  const bot = registry.registerPrincipal({ displayName: "Release Bot", kind: "automation" });
+  registry.addBinding(alex.id, { provider: "jira", connection: "delivery-jira", tenantId: "t1", accountId: "acc-alex", verifiedVia: "authenticated-self-binding", verifiedBy: alex.id, verifiedAt: "2026-08-15T17:40:00.000Z" });
+  registry.addBinding(sam.id, { provider: "jira", connection: "delivery-jira", tenantId: "t1", accountId: "acc-sam", verifiedVia: "administrator-attestation", verifiedBy: alex.id, verifiedAt: "2026-08-15T17:41:00.000Z" });
+  registry.addBinding(bot.id, { provider: "jira", connection: "delivery-jira", tenantId: "t1", accountId: "acc-bot", verifiedVia: "administrator-attestation", verifiedBy: alex.id, verifiedAt: "2026-08-15T17:42:00.000Z" });
+  return { registry, alex, sam, bot };
+}
+
+function pkg() {
+  return buildApprovalPackage({
+    artifactHashes: [H("a")],
+    policyVersions: ["approval/v1"],
+    requiredApprovers: [{ principal: mintIdentity(), role: "product-owner" }]
+  });
+}
+
+test("FEAT-009: bindings require accepted verification methods; manual matches are unverified (§27.2)", () => {
+  const registry = new IdentityRegistry();
+  const p = registry.registerPrincipal({ displayName: "X", kind: "human" });
+  assert.throws(
+    () => registry.addBinding(p.id, { provider: "jira", connection: "c", accountId: "a", verifiedVia: "email-match", verifiedBy: p.id, verifiedAt: "t" }),
+    /unaccepted verification method/
+  );
+  assert.throws(() => registry.addBinding(p.id, { provider: "jira", connection: "c", accountId: "", verifiedVia: "authenticated-self-binding", verifiedBy: p.id, verifiedAt: "t" }), ApprovalError);
+});
+
+test("FEAT-009: approval packages are immutable and reproducible (§27.4)", () => {
+  const a = pkg();
+  assert.ok(Object.isFrozen(a));
+  assert.match(a.package_hash, /^sha256:[0-9a-f]{64}$/);
+  const b = buildApprovalPackage({
+    artifactHashes: a.artifact_hashes,
+    policyVersions: a.policy_versions,
+    requiredApprovers: a.required_approvers
+  });
+  assert.equal(a.package_hash, b.package_hash, "same content reproduces the same hash");
+});
+
+test("FEAT-009: decisions bind principal, verified binding, and exact package hash (§27.4)", () => {
+  const { registry, alex } = registryWith();
+  const opened = pkg();
+  const decision = recordDecision(registry, {
+    provider: "jira", connection: "delivery-jira", accountId: "acc-alex",
+    decision: "approve", packageHash: opened.package_hash, expectedPackageHash: opened.package_hash,
+    role: "product-owner", authenticationContext: "oauth-session-913", at: "2026-08-15T18:00:00.000Z"
+  });
+  assert.equal(decision.principal, alex.id);
+  assert.equal(decision.package_hash, opened.package_hash);
+  assert.match(decision.decision_hash, /^sha256:[0-9a-f]{64}$/);
+  assert.ok(Object.isFrozen(decision));
+});
+
+test("FEAT-009: a stale hash or unknown account is rejected (§27.6, §46 step 8)", () => {
+  const { registry } = registryWith();
+  const opened = pkg();
+  assert.throws(
+    () => recordDecision(registry, {
+      provider: "jira", connection: "delivery-jira", accountId: "acc-alex",
+      decision: "approve", packageHash: H("f"), expectedPackageHash: opened.package_hash,
+      role: "product-owner", authenticationContext: "ctx", at: "t"
+    }),
+    /does not match the open approval package/
+  );
+  assert.throws(
+    () => recordDecision(registry, {
+      provider: "jira", connection: "delivery-jira", accountId: "acc-wrong",
+      decision: "approve", packageHash: opened.package_hash, expectedPackageHash: opened.package_hash,
+      role: "product-owner", authenticationContext: "ctx", at: "t"
+    }),
+    /no verified binding resolves/
+  );
+});
+
+test("FEAT-009: a revoked binding prevents future decisions but keeps history (§27.2)", () => {
+  const { registry } = registryWith();
+  const opened = pkg();
+  const first = recordDecision(registry, {
+    provider: "jira", connection: "delivery-jira", accountId: "acc-sam",
+    decision: "approve", packageHash: opened.package_hash, expectedPackageHash: opened.package_hash,
+    role: "compliance", authenticationContext: "ctx", at: "t1"
+  });
+  registry.revokeBinding(first.principal, "acc-sam", { at: "t2" });
+  assert.throws(
+    () => recordDecision(registry, {
+      provider: "jira", connection: "delivery-jira", accountId: "acc-sam",
+      decision: "approve", packageHash: opened.package_hash, expectedPackageHash: opened.package_hash,
+      role: "compliance", authenticationContext: "ctx", at: "t3"
+    }),
+    /no verified binding/
+  );
+  assert.equal(first.decision, "approve", "historical evidence retained");
+});
+
+test("FEAT-009: policies — all-required, n-of-m, one-per-role; declines block (§27.3)", () => {
+  const { registry, alex, sam } = registryWith();
+  const opened = pkg();
+  const decide = (accountId, role, decision = "approve") => recordDecision(registry, {
+    provider: "jira", connection: "delivery-jira", accountId,
+    decision, packageHash: opened.package_hash, expectedPackageHash: opened.package_hash,
+    role, authenticationContext: "ctx", at: "t"
+  });
+  const a = decide("acc-alex", "product-owner");
+  const s = decide("acc-sam", "compliance");
+
+  assert.equal(evaluatePolicy({ kind: "all-required", required: [alex.id, sam.id] }, [a, s], { packageHash: opened.package_hash, registry }).satisfied, true);
+  assert.equal(evaluatePolicy({ kind: "all-required", required: [alex.id, sam.id] }, [a], { packageHash: opened.package_hash, registry }).satisfied, false);
+  assert.equal(evaluatePolicy({ kind: "n-of-m", eligible: [alex.id, sam.id], quorum: 1 }, [a], { packageHash: opened.package_hash, registry }).satisfied, true);
+  assert.equal(evaluatePolicy({ kind: "one-per-role", roles: ["product-owner", "compliance"] }, [a, s], { packageHash: opened.package_hash, registry }).satisfied, true);
+  assert.equal(evaluatePolicy({ kind: "one-per-role", roles: ["product-owner", "compliance"] }, [a], { packageHash: opened.package_hash, registry }).satisfied, false);
+
+  const decline = decide("acc-sam", "compliance", "reject");
+  const declined = evaluatePolicy({ kind: "all-required", required: [alex.id, sam.id] }, [a, decline], { packageHash: opened.package_hash, registry });
+  assert.equal(declined.satisfied, false);
+  assert.match(declined.reason, /declined/);
+});
+
+test("FEAT-009: an automation principal never satisfies a human role (§27.2)", () => {
+  const { registry } = registryWith();
+  const opened = pkg();
+  const bot = recordDecision(registry, {
+    provider: "jira", connection: "delivery-jira", accountId: "acc-bot",
+    decision: "approve", packageHash: opened.package_hash, expectedPackageHash: opened.package_hash,
+    role: "product-owner", authenticationContext: "ctx", at: "t"
+  });
+  assert.throws(
+    () => evaluatePolicy({ kind: "one-per-role", roles: ["product-owner"] }, [bot], { packageHash: opened.package_hash, registry }),
+    /non-human principal cannot satisfy human role/
+  );
+  // Explicitly authorized deterministic roles are permitted (§27.2).
+  const allowed = evaluatePolicy(
+    { kind: "one-per-role", roles: ["release-check"], automationRoles: ["release-check"] },
+    [{ ...bot, role: "release-check" }],
+    { packageHash: opened.package_hash, registry }
+  );
+  assert.equal(allowed.satisfied, true);
+});
+
+test("FEAT-009: readiness requires verified approvers, evidence, and a reproducible package (§27.5)", () => {
+  const { registry, alex } = registryWith();
+  const stranger = mintIdentity();
+  const bad = readinessCheck({
+    templatesPass: false,
+    blockingFindings: [{ id: "F-1" }],
+    evidenceLinks: [],
+    dependencyCycles: [["a", "b", "a"]],
+    approverSet: [alex.id, stranger],
+    registry,
+    reproduciblePackage: false
+  });
+  assert.equal(bad.ready, false);
+  assert.ok(bad.failures.length >= 5);
+  const good = readinessCheck({
+    templatesPass: true,
+    blockingFindings: [{ id: "F-1" }],
+    waivers: [{ finding: "F-1", valid: true }],
+    evidenceLinks: ["kb://x"],
+    approverSet: [alex.id],
+    registry,
+    reproduciblePackage: true
+  });
+  assert.equal(good.ready, true);
+});
+
+test("FEAT-009: baselines are immutable and reproduce their root hash", () => {
+  const opened = pkg();
+  const baseline = createBaseline({
+    packages: [opened],
+    artifactHashes: [H("a")],
+    metadata: { title: "BL-1" }
+  });
+  assert.ok(Object.isFrozen(baseline));
+  assert.match(baseline.baseline_root_hash, /^sha256:[0-9a-f]{64}$/);
+  const again = createBaseline({ packages: [opened], artifactHashes: [H("a")], metadata: { title: "BL-1" } });
+  assert.equal(baseline.baseline_root_hash, again.baseline_root_hash);
+  assert.throws(() => createBaseline({ packages: [], artifactHashes: [H("a")] }), ApprovalError);
+});
+
+test("FEAT-009: redaction preserves tombstones and original hashes without rewriting the baseline (§41.1)", () => {
+  const opened = pkg();
+  const artifact = mintIdentity();
+  const baseline = createBaseline({ packages: [opened], artifactHashes: [H("a")] });
+  const tombstone = createTombstone({
+    artifact,
+    originalContentHash: H("c"),
+    affectedPackage: opened.package_hash,
+    affectedBaseline: baseline.baseline_root_hash,
+    actor: mintIdentity(),
+    authority: "privacy-office",
+    scope: "statement",
+    reasonCode: "gdpr-erasure",
+    decisionAt: "2026-08-15T22:00:00.000Z"
+  });
+  assert.equal(tombstone.original_content_hash, H("c"));
+  assert.throws(
+    () => createTombstone({ artifact, originalContentHash: H("c"), affectedPackage: "p", affectedBaseline: "b", actor: "a", authority: "x", scope: "s", reasonCode: "r", decisionAt: "t", content: "the secret" }),
+    /must exclude the content/
+  );
+
+  const { addendum, projected_state, baseline: untouched } = applyRedaction(baseline, {
+    tombstones: [tombstone],
+    authority: "privacy-office",
+    storageBoundary: "repository",
+    nonReconstructable: true,
+    exceptions: ["provider backup retention until 2026-12-01"]
+  });
+  assert.equal(projected_state, "non-reconstructable");
+  assert.equal(untouched.baseline_root_hash, baseline.baseline_root_hash, "original root untouched");
+  assert.equal(addendum.original_baseline_root, baseline.baseline_root_hash);
+  assert.match(addendum.addendum_hash, /^sha256:[0-9a-f]{64}$/);
+  assert.deepEqual(addendum.deletion_exceptions, ["provider backup retention until 2026-12-01"]);
+  assert.ok(!JSON.stringify(addendum).includes("the secret"));
+});

--- a/tests/governance/approval.test.mjs
+++ b/tests/governance/approval.test.mjs
@@ -324,3 +324,24 @@ test("FEAT-009: baselines are deeply frozen (review LOW)", () => {
   assert.throws(() => { baseline.source_locks[0].rev = 2; }, TypeError);
   assert.throws(() => { baseline.metadata.nested.x = 2; }, TypeError);
 });
+
+test("FEAT-009: role-less humans cannot assert roles; SoD finds valid matchings regardless of order", () => {
+  const registry = new IdentityRegistry();
+  const noRoles = registry.registerPrincipal({ displayName: "N", kind: "human" });
+  registry.addBinding(noRoles.id, { provider: "jira", connection: "c", accountId: "acc-n", verifiedVia: "authenticated-self-binding", verifiedBy: noRoles.id, verifiedAt: "t" });
+  const opened = pkg();
+  assert.throws(
+    () => recordDecision(registry, { provider: "jira", connection: "c", accountId: "acc-n", decision: "approve", packageHash: opened.package_hash, expectedPackageHash: opened.package_hash, role: "compliance", authenticationContext: "ctx", at: "t" }),
+    /does not hold role/
+  );
+  // P1 holds A+B, P2 holds only B: role order [B, A] must still find the matching.
+  const m = new IdentityRegistry();
+  const p1 = m.registerPrincipal({ displayName: "P1", kind: "human", roles: ["a", "b"] });
+  const p2 = m.registerPrincipal({ displayName: "P2", kind: "human", roles: ["b"] });
+  m.addBinding(p1.id, { provider: "jira", connection: "c", accountId: "acc-p1", verifiedVia: "authenticated-self-binding", verifiedBy: p1.id, verifiedAt: "t" });
+  m.addBinding(p2.id, { provider: "jira", connection: "c", accountId: "acc-p2", verifiedVia: "authenticated-self-binding", verifiedBy: p2.id, verifiedAt: "t" });
+  const mk = (acc, role) => recordDecision(m, { provider: "jira", connection: "c", accountId: acc, decision: "approve", packageHash: opened.package_hash, expectedPackageHash: opened.package_hash, role, authenticationContext: "ctx", at: "t" });
+  const decisions = [mk("acc-p1", "a"), mk("acc-p1", "b"), mk("acc-p2", "b")];
+  const result = evaluatePolicy({ kind: "one-per-role", roles: ["b", "a"], separationOfDuties: true }, decisions, { packageHash: opened.package_hash, registry: m });
+  assert.equal(result.satisfied, true, "backtracking finds p2->b, p1->a");
+});

--- a/tests/governance/approval.test.mjs
+++ b/tests/governance/approval.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   ApprovalError,
   IdentityRegistry,
+  verifyDecision,
   applyRedaction,
   buildApprovalPackage,
   createBaseline,
@@ -148,9 +149,14 @@ test("FEAT-009: an automation principal never satisfies a human role (§27.2)", 
     /non-human principal cannot satisfy human role/
   );
   // Explicitly authorized deterministic roles are permitted (§27.2).
+  const botCheck = recordDecision(registry, {
+    provider: "jira", connection: "delivery-jira", accountId: "acc-bot",
+    decision: "approve", packageHash: opened.package_hash, expectedPackageHash: opened.package_hash,
+    role: "release-check", authenticationContext: "ctx", at: "t"
+  });
   const allowed = evaluatePolicy(
     { kind: "one-per-role", roles: ["release-check"], automationRoles: ["release-check"] },
-    [{ ...bot, role: "release-check" }],
+    [botCheck],
     { packageHash: opened.package_hash, registry }
   );
   assert.equal(allowed.satisfied, true);
@@ -230,4 +236,91 @@ test("FEAT-009: redaction preserves tombstones and original hashes without rewri
   assert.match(addendum.addendum_hash, /^sha256:[0-9a-f]{64}$/);
   assert.deepEqual(addendum.deletion_exceptions, ["provider backup retention until 2026-12-01"]);
   assert.ok(!JSON.stringify(addendum).includes("the secret"));
+});
+
+test("FEAT-009: forged or mutated decision records fail integrity verification (review HIGH)", () => {
+  const { registry, alex } = registryWith();
+  const opened = pkg();
+  const forged = { principal: alex.id, principal_kind: "human", decision: "approve", package_hash: opened.package_hash, role: "product-owner" };
+  assert.throws(
+    () => evaluatePolicy({ kind: "all-required", required: [alex.id] }, [forged], { packageHash: opened.package_hash, registry }),
+    /fails integrity verification/
+  );
+  const real = recordDecision(registry, {
+    provider: "jira", connection: "delivery-jira", accountId: "acc-alex",
+    decision: "reject", packageHash: opened.package_hash, expectedPackageHash: opened.package_hash,
+    role: "product-owner", authenticationContext: "ctx", at: "t"
+  });
+  const flipped = { ...real, decision: "approve" };
+  assert.throws(
+    () => evaluatePolicy({ kind: "all-required", required: [alex.id] }, [flipped], { packageHash: opened.package_hash, registry }),
+    /fails integrity verification/
+  );
+  assert.equal(verifyDecision(real), true);
+  assert.equal(verifyDecision(flipped), false);
+});
+
+test("FEAT-009: one provider account binds to exactly one principal (review HIGH)", () => {
+  const registry = new IdentityRegistry();
+  const a = registry.registerPrincipal({ displayName: "A", kind: "human" });
+  const b = registry.registerPrincipal({ displayName: "B", kind: "human" });
+  registry.addBinding(a.id, { provider: "jira", connection: "c", accountId: "acc-1", verifiedVia: "authenticated-self-binding", verifiedBy: a.id, verifiedAt: "t" });
+  assert.throws(
+    () => registry.addBinding(b.id, { provider: "jira", connection: "c", accountId: "acc-1", verifiedVia: "administrator-attestation", verifiedBy: a.id, verifiedAt: "t" }),
+    /already bound to principal/
+  );
+  // After revocation the account may be re-bound.
+  registry.revokeBinding(a.id, "acc-1", { at: "t2" });
+  registry.addBinding(b.id, { provider: "jira", connection: "c", accountId: "acc-1", verifiedVia: "administrator-attestation", verifiedBy: a.id, verifiedAt: "t3" });
+});
+
+test("FEAT-009: asserted roles must be held; separation of duties requires distinct principals (review MEDIUM)", () => {
+  const { registry } = registryWith();
+  const opened = pkg();
+  assert.throws(
+    () => recordDecision(registry, {
+      provider: "jira", connection: "delivery-jira", accountId: "acc-alex",
+      decision: "approve", packageHash: opened.package_hash, expectedPackageHash: opened.package_hash,
+      role: "compliance", authenticationContext: "ctx", at: "t"
+    }),
+    /does not hold role/
+  );
+  // One principal holding both roles cannot satisfy SoD alone.
+  const multi = new IdentityRegistry();
+  const solo = multi.registerPrincipal({ displayName: "Solo", kind: "human", roles: ["product-owner", "compliance"] });
+  multi.addBinding(solo.id, { provider: "jira", connection: "c", accountId: "acc-solo", verifiedVia: "authenticated-self-binding", verifiedBy: solo.id, verifiedAt: "t" });
+  const d1 = recordDecision(multi, { provider: "jira", connection: "c", accountId: "acc-solo", decision: "approve", packageHash: opened.package_hash, expectedPackageHash: opened.package_hash, role: "product-owner", authenticationContext: "ctx", at: "t" });
+  const d2 = recordDecision(multi, { provider: "jira", connection: "c", accountId: "acc-solo", decision: "approve", packageHash: opened.package_hash, expectedPackageHash: opened.package_hash, role: "compliance", authenticationContext: "ctx", at: "t" });
+  const relaxed = evaluatePolicy({ kind: "one-per-role", roles: ["product-owner", "compliance"] }, [d1, d2], { packageHash: opened.package_hash, registry: multi });
+  assert.equal(relaxed.satisfied, true, "without SoD one principal may fill both roles");
+  const strict = evaluatePolicy({ kind: "one-per-role", roles: ["product-owner", "compliance"], separationOfDuties: true }, [d1, d2], { packageHash: opened.package_hash, registry: multi });
+  assert.equal(strict.satisfied, false);
+  assert.match(strict.reason, /distinct principals/);
+});
+
+test("FEAT-009: redaction addenda bind to their baseline and hash order-stably (review MEDIUM)", () => {
+  const opened = pkg();
+  const baseline = createBaseline({ packages: [opened], artifactHashes: [H("a")] });
+  const other = createBaseline({ packages: [opened], artifactHashes: [H("b")] });
+  const mk = (artifact, root) => createTombstone({
+    artifact, originalContentHash: H("c"), affectedPackage: opened.package_hash, affectedBaseline: root,
+    actor: mintIdentity(), authority: "privacy-office", scope: "s", reasonCode: "r", decisionAt: "t"
+  });
+  const t1 = mk(mintIdentity(), baseline.baseline_root_hash);
+  const t2 = mk(mintIdentity(), baseline.baseline_root_hash);
+  const wrong = mk(mintIdentity(), other.baseline_root_hash);
+  assert.throws(
+    () => applyRedaction(baseline, { tombstones: [wrong], authority: "x", storageBoundary: "repo" }),
+    /different baseline/
+  );
+  const forward = applyRedaction(baseline, { tombstones: [t1, t2], authority: "x", storageBoundary: "repo" });
+  const reversed = applyRedaction(baseline, { tombstones: [t2, t1], authority: "x", storageBoundary: "repo" });
+  assert.equal(forward.addendum.addendum_hash, reversed.addendum.addendum_hash);
+});
+
+test("FEAT-009: baselines are deeply frozen (review LOW)", () => {
+  const opened = pkg();
+  const baseline = createBaseline({ packages: [opened], artifactHashes: [H("a")], sourceLocks: [{ id: "L1", rev: 1 }], metadata: { nested: { x: 1 } } });
+  assert.throws(() => { baseline.source_locks[0].rev = 2; }, TypeError);
+  assert.throws(() => { baseline.metadata.nested.x = 2; }, TypeError);
 });


### PR DESCRIPTION
## Outcome

Implements the Governed-Basic core per §27/§41.1: the identity registry with verified provider bindings (accepted methods only — manual email/display-name matches are structurally unverifiable), revocation that blocks future decisions while preserving history, immutable reproducible rdlc-jcs-v1 approval packages, decisions bound to canonical principal + verified binding + exact package hash (stale hashes and unknown accounts rejected), approval policies (all-required, n-of-m, one-per-role, decline behavior, explicit automation-role allowance with the human floor), §27.5 readiness checks, immutable baselines with reproducible root hashes, and §41.1 redaction tombstones/addenda that never rewrite the historical baseline root.

Closes #10

## Traceability

- Requirement IDs: FEAT-009
- Specification sections: §27.2–27.5, §41.1, §14.1
- Conformance modules affected: Governed-Basic
- Traceability index updated: yes — FEAT-009 verified

## Gate evidence

- [x] Feature/requirement definition is complete and linked.
- [x] Implementation plan received the required review (ADR-001 item 10: Jira `myself` self-binding model).
- [x] Development stayed within issue scope.
- [x] Deterministic tests cover acceptance and failure criteria.
- [x] Final review considered correctness, security, and traceability.

Commands and results:

```text
npm test
> check:governance — Governance verified: 13 traceable requirements and 5 development gates.
> test:governance — 128 pass, 0 fail (unverified-method rejection; package immutability + hash reproduction; stale-hash and wrong-account rejection; revocation semantics; three policy kinds + decline; automation-in-human-role rejection with explicit automation-role allowance; readiness failures; baseline immutability/reproduction; tombstone content exclusion; addendum leaves original root untouched)
```

## Security, privacy, rights, and retention

The §14.6/§27.2 floor is code-enforced: no unverified identity, shared account, or automation principal satisfies a human approval; redaction excludes removed content by construction and records deletion exceptions explicitly.

## Compatibility, migration, and rollback

Additive library over FEAT-003 hash profiles. Rollback = revert.

## Release and documentation

Completes §46 steps 8–9 and 13 machinery; connector read-back binding (step 8's provider side) lands with FEAT-010.
