### PR TITLE
feat: setup installer and distribution packaging (#32) [FEAT-013]

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ durable checkpoints.
 - **Bounded document intake** — anchored evidence from PDF, Office, diagrams,
   images, and email without executing untrusted content (spec §16)
 
+## Install
+
+```bash
+npx github:aithinkers/requirements-dlc
+```
+
+installs the Claude Code plugin (26 `/rdlc-*` commands + 10 role agents), a
+§47-defaults `requirements-project.yaml`, and the `rdlc/` engagement layout
+into your project — idempotently, without clobbering your edits. Then open
+the project in Claude Code and run `/rdlc-start`. Full walkthrough:
+[docs/getting-started.md](docs/getting-started.md).
+
 ## Development process
 
 This repository uses issue-first, review-gated development enforced by CI.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,82 @@
+# Getting started with R-DLC
+
+R-DLC turns ideas, scope documents, and tracker backlogs into governed,
+traceable requirements — with portable files as the durable contract.
+
+## Install
+
+From the project you want to govern (any directory works):
+
+```bash
+npx github:aithinkers/requirements-dlc
+```
+
+or, from a clone:
+
+```bash
+node scripts/setup.mjs --target /path/to/your-project
+```
+
+Setup is idempotent and never overwrites files you have modified (rerun with
+`--force` to replace them; `--check` reports drift without writing). It
+installs:
+
+- `.claude/plugins/rdlc/` — the Claude Code plugin: 26 `/rdlc-*` commands and
+  the ten §38 role agents, generated from the authored core and byte-exact
+  drift-protected
+- `requirements-project.yaml` — a §47-defaults project manifest
+  (files-authoritative, propose-only connectors, untrusted external content)
+- `rdlc/` — the §11 space/engagement layout
+
+## First engagement
+
+Open the project in Claude Code:
+
+1. `/rdlc-start` — begin (or resume) an engagement; state lives in
+   `rdlc/…/rdlc-state.yaml` with atomic checkpoints, so any session can
+   resume from the last safe checkpoint.
+2. `/rdlc-capture` — drop in an idea, meeting note, or scope document.
+   Bounded intake handles PDF, DOCX, Markdown, HTML, XLSX, CSV, PPTX,
+   draw.io, VSDX, images, and EML — encrypted, macro-enabled, and oversized
+   inputs fail closed.
+3. `/rdlc-triage` then `/rdlc-promote` — captures become typed working
+   artifacts; the thirteen-step promotion gate checks freshness, coverage,
+   duplicates, collisions, and dependency cycles before anything enters the
+   shared draft graph.
+4. `/rdlc-review` — deterministic checks plus the clearly labeled initial
+   semantic review (suggestions, never silent truth).
+5. `/rdlc-readiness` and `/rdlc-approve` — approvals bind verified provider
+   identities to the exact `rdlc-jcs-v1` package hash; wrong accounts and
+   stale hashes are rejected in code.
+6. `/rdlc-sync` — connector writes are previewed changesets with idempotent
+   apply, read-back verification, and receipts. The default write mode is
+   `propose`; nothing touches your tracker without the configured approval.
+
+`/rdlc-status` answers "where was I?" from durable files alone, and
+`/rdlc-doctor` validates installation, policy, and state.
+
+## Working as a team
+
+Declare advisory scope with `/rdlc-claim` (overlaps notify, never block),
+work in per-BA branches, and let the promotion gate + mutation leases
+serialize the moments that must be exclusive (alias allocation, baselines).
+Stale writes stop with a base/current/proposed comparison — deletions
+included.
+
+## Using the libraries directly
+
+Every governed capability is an importable module:
+
+```js
+import { intake } from "requirements-dlc/intake";
+import { contentHash } from "requirements-dlc/canonical";
+import { JiraConnector } from "requirements-dlc/connectors/jira";
+```
+
+## Conformance
+
+This distribution claims Core, Governed-Basic, and Planning (declared partial
+depth) with the Jira Cloud company-managed connector subset and the Claude
+Code harness — see
+[`distribution/release/conformance-statement.json`](../distribution/release/conformance-statement.json)
+for the exact claim, exceptions, and evidence. It never claims `Full`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,9 @@ node scripts/setup.mjs --target /path/to/your-project
 ```
 
 Setup is idempotent and never overwrites files you have modified (rerun with
-`--force` to replace them; `--check` reports drift without writing). It
+`--force` to replace them; `--check` reports drift without writing). Exit
+codes: `0` success or up-to-date, `1` drift found or setup error, `2`
+completed but user-modified files were protected. It
 installs:
 
 - `.claude/plugins/rdlc/` — the Claude Code plugin: 26 `/rdlc-*` commands and

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -342,6 +342,27 @@
           "tests/governance/engagement.test.mjs"
         ]
       }
+    },
+    {
+      "id": "FEAT-013",
+      "title": "Setup installer, package metadata, and quick start for distribution",
+      "issue": 32,
+      "specification_sections": [
+        "§11",
+        "§36",
+        "§47"
+      ],
+      "status": "verified",
+      "evidence": {
+        "implementation": [
+          "scripts/setup.mjs",
+          "package.json",
+          "docs/getting-started.md"
+        ],
+        "tests": [
+          "tests/governance/engagement.test.mjs"
+        ]
+      }
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "requirements-dlc",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": false,
   "description": "R-DLC development and governance tooling",
   "license": "MIT",
@@ -42,5 +42,43 @@
   },
   "devDependencies": {
     "ajv": "8.20.0"
+  },
+  "bin": {
+    "rdlc-setup": "./scripts/setup.mjs"
+  },
+  "files": [
+    "core/",
+    "dist/",
+    "scripts/setup.mjs",
+    "scripts/generate-distribution.mjs",
+    "scripts/scale-fixture.mjs",
+    "scripts/run-scale-benchmark.mjs",
+    "scripts/migrate-legacy.mjs",
+    "distribution/release/",
+    "docs/getting-started.md",
+    "README.md",
+    "SECURITY.md",
+    "SUPPORT.md",
+    "LICENSE"
+  ],
+  "exports": {
+    "./canonical": "./core/lib/canonical.mjs",
+    "./identity": "./core/lib/identity.mjs",
+    "./lifecycle": "./core/lib/lifecycle.mjs",
+    "./promotion": "./core/lib/promotion.mjs",
+    "./collaboration": "./core/lib/collaboration.mjs",
+    "./approval": "./core/lib/approval.mjs",
+    "./intake": "./core/lib/intake/index.mjs",
+    "./templates": "./core/lib/templates.mjs",
+    "./elicitation": "./core/lib/elicitation.mjs",
+    "./components": "./core/lib/components.mjs",
+    "./estimation": "./core/lib/estimation.mjs",
+    "./raid": "./core/lib/raid.mjs",
+    "./comments": "./core/lib/comments.mjs",
+    "./planning": "./core/lib/planning.mjs",
+    "./semantic-review": "./core/lib/semantic-review.mjs",
+    "./engagement": "./core/lib/engagement.mjs",
+    "./connectors/jira": "./core/connectors/jira/index.mjs",
+    "./schemas": "./core/schemas/v0.2/index.mjs"
   }
 }

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+/**
+ * R-DLC setup installer (issue #32).
+ *
+ * Installs the generated Claude Code plugin into a target project and
+ * scaffolds a governed R-DLC project per §11 with §47 recommended defaults.
+ * Idempotent: unchanged files are skipped; files the user modified are never
+ * overwritten without --force, and every action is reported.
+ *
+ * Usage:
+ *   npx github:aithinkers/requirements-dlc [--target <dir>] [--force] [--check]
+ *   node scripts/setup.mjs --target ~/my-project
+ */
+
+import { createHash } from "node:crypto";
+import { mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import process from "node:process";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function parseArguments(argv) {
+  const options = { target: process.cwd(), force: false, check: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === "--target") options.target = resolve(argv[++index] ?? ".");
+    else if (argv[index] === "--force") options.force = true;
+    else if (argv[index] === "--check") options.check = true;
+    else if (argv[index] === "--help" || argv[index] === "-h") options.help = true;
+    else throw new Error(`unknown option: ${argv[index]}`);
+  }
+  return options;
+}
+
+const sha256 = (bytes) => createHash("sha256").update(bytes).digest("hex");
+
+async function listPluginFiles() {
+  const base = join(packageRoot, "dist", "claude-code");
+  const files = [];
+  for (const directory of ["commands", "agents", ".claude-plugin"]) {
+    for (const name of await readdir(join(base, directory))) {
+      files.push({
+        source: join(base, directory, name),
+        relative: join(".claude", "plugins", "rdlc", directory, name)
+      });
+    }
+  }
+  return files;
+}
+
+/** §11 project scaffold with §47 recommended defaults. */
+function projectManifest(projectId) {
+  return `schema_version: rdlc.project/v0.2
+
+project:
+  id: ${projectId}
+  title: ${projectId}
+  default_space: main
+  authority_mode: files-authoritative
+
+knowledge:
+  enabled: false
+
+approval:
+  default_policy: all-required-by-role
+  material_change_policy: invalidate-affected
+
+collaboration:
+  lease_authority:
+    kind: git-ref-compare-and-swap
+    remote: origin
+    ref_namespace: refs/rdlc/leases
+  alias_authority: lease-protected-counter
+
+estimation:
+  default_profile: team-story-points
+  allow_ai_suggestions: true
+  confirmation_required: true
+
+connectors: []
+
+security:
+  external_content: untrusted
+  secrets_provider: environment
+`;
+}
+
+const SCAFFOLD_DIRECTORIES = [
+  "rdlc/spaces/main/policy",
+  "rdlc/spaces/main/templates",
+  "rdlc/spaces/main/stakeholders",
+  "rdlc/spaces/main/identities",
+  "rdlc/spaces/main/collaboration/claims",
+  "rdlc/spaces/main/collaboration/leases",
+  "rdlc/spaces/main/engagements"
+];
+
+async function fileState(path, expected) {
+  try {
+    const current = await readFile(path);
+    return sha256(current) === sha256(expected) ? "unchanged" : "modified";
+  } catch {
+    return "absent";
+  }
+}
+
+export async function runSetup({ target, force = false, check = false, log = console.log }) {
+  const results = { installed: [], skipped: [], protected: [], scaffolded: [], drift: [] };
+  try {
+    await stat(target);
+  } catch {
+    throw new Error(`target directory does not exist: ${target}`);
+  }
+
+  const plan = await listPluginFiles();
+  const projectId = target.split("/").filter(Boolean).at(-1) ?? "rdlc-project";
+  plan.push({ content: projectManifest(projectId), relative: "requirements-project.yaml" });
+
+  for (const entry of plan) {
+    const destination = join(target, entry.relative);
+    const expected = entry.content !== undefined ? Buffer.from(entry.content) : await readFile(entry.source);
+    const state = await fileState(destination, expected);
+    if (check) {
+      if (state !== "unchanged") results.drift.push({ file: entry.relative, state });
+      continue;
+    }
+    if (state === "unchanged") {
+      results.skipped.push(entry.relative);
+      continue;
+    }
+    if (state === "modified" && !force) {
+      // Never clobber a user-modified file silently.
+      results.protected.push(entry.relative);
+      continue;
+    }
+    await mkdir(dirname(destination), { recursive: true });
+    await writeFile(destination, expected);
+    results.installed.push(entry.relative);
+  }
+
+  if (!check) {
+    for (const directory of SCAFFOLD_DIRECTORIES) {
+      const destination = join(target, directory);
+      try {
+        await stat(destination);
+      } catch {
+        await mkdir(destination, { recursive: true });
+        await writeFile(join(destination, ".gitkeep"), "");
+        results.scaffolded.push(directory);
+      }
+    }
+  }
+
+  log(`R-DLC setup ${check ? "check" : "install"} for ${target}`);
+  if (check) {
+    log(results.drift.length === 0 ? "  up to date" : results.drift.map((entry) => `  drift: ${entry.file} (${entry.state})`).join("\n"));
+  } else {
+    log(`  installed: ${results.installed.length}, unchanged: ${results.skipped.length}, scaffolded: ${results.scaffolded.length}`);
+    for (const file of results.protected) {
+      log(`  PROTECTED (user-modified, use --force to overwrite): ${file}`);
+    }
+    if (results.installed.length > 0 || results.scaffolded.length > 0) {
+      log("\nNext: open the project in Claude Code and run /rdlc-start (see docs/getting-started.md).");
+    }
+  }
+  return results;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const options = parseArguments(process.argv.slice(2));
+  if (options.help) {
+    console.log("Usage: rdlc-setup [--target <dir>] [--force] [--check]");
+    process.exit(0);
+  }
+  const results = await runSetup(options);
+  if (options.check && results.drift.length > 0) process.exit(1);
+  if (results.protected.length > 0) process.exit(2);
+}

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -14,7 +14,7 @@
 
 import { createHash } from "node:crypto";
 import { mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import process from "node:process";
 
@@ -106,14 +106,16 @@ async function fileState(path, expected) {
 
 export async function runSetup({ target, force = false, check = false, log = console.log }) {
   const results = { installed: [], skipped: [], protected: [], scaffolded: [], drift: [] };
+  let targetStat;
   try {
-    await stat(target);
+    targetStat = await stat(target);
   } catch {
     throw new Error(`target directory does not exist: ${target}`);
   }
+  if (!targetStat.isDirectory()) throw new Error(`target is not a directory: ${target}`);
 
   const plan = await listPluginFiles();
-  const projectId = target.split("/").filter(Boolean).at(-1) ?? "rdlc-project";
+  const projectId = basename(resolve(target)) || "rdlc-project";
   plan.push({ content: projectManifest(projectId), relative: "requirements-project.yaml" });
 
   for (const entry of plan) {
@@ -169,10 +171,19 @@ export async function runSetup({ target, force = false, check = false, log = con
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   const options = parseArguments(process.argv.slice(2));
   if (options.help) {
-    console.log("Usage: rdlc-setup [--target <dir>] [--force] [--check]");
+    console.log(`Usage: rdlc-setup [--target <dir>] [--force] [--check]
+
+Exit codes: 0 success/up-to-date; 1 drift found (--check) or setup error;
+2 completed but user-modified files were protected (rerun with --force).`);
     process.exit(0);
   }
-  const results = await runSetup(options);
+  let results;
+  try {
+    results = await runSetup(options);
+  } catch (error) {
+    console.error(`rdlc-setup: ${error.message}`);
+    process.exit(1);
+  }
   if (options.check && results.drift.length > 0) process.exit(1);
   if (results.protected.length > 0) process.exit(2);
 }

--- a/tests/governance/engagement.test.mjs
+++ b/tests/governance/engagement.test.mjs
@@ -183,3 +183,34 @@ test("FEAT-012: the plugin manifest points at generated agents and commands and 
     await writeFile(target, original, "utf8");
   }
 });
+
+test("FEAT-013: setup installs the plugin and scaffold idempotently and protects user edits", async () => {
+  const { runSetup } = await import("../../scripts/setup.mjs");
+  const target = await mkdtemp(join(tmpdir(), "rdlc-setup-"));
+  const quiet = () => {};
+
+  const first = await runSetup({ target, log: quiet });
+  assert.ok(first.installed.includes("requirements-project.yaml"));
+  assert.ok(first.installed.some((file) => file.endsWith(join("commands", "rdlc-start.md"))));
+  assert.ok(first.installed.some((file) => file.endsWith(join("agents", "rdlc-facilitator.md"))));
+  assert.ok(first.installed.some((file) => file.endsWith(join(".claude-plugin", "plugin.json"))));
+  assert.ok(first.scaffolded.includes("rdlc/spaces/main/engagements"));
+  const manifest = await readFile(join(target, "requirements-project.yaml"), "utf8");
+  assert.match(manifest, /authority_mode: files-authoritative/);
+  assert.match(manifest, /external_content: untrusted/);
+
+  // Idempotent: a second run changes nothing.
+  const second = await runSetup({ target, log: quiet });
+  assert.equal(second.installed.length, 0);
+  assert.equal(second.scaffolded.length, 0);
+  assert.equal((await runSetup({ target, check: true, log: quiet })).drift.length, 0);
+
+  // User-modified files are protected without --force.
+  await writeFile(join(target, "requirements-project.yaml"), manifest + "# my edit\n", "utf8");
+  const third = await runSetup({ target, log: quiet });
+  assert.deepEqual(third.protected, ["requirements-project.yaml"]);
+  assert.match(await readFile(join(target, "requirements-project.yaml"), "utf8"), /# my edit/);
+  const forced = await runSetup({ target, force: true, log: quiet });
+  assert.deepEqual(forced.installed, ["requirements-project.yaml"]);
+  await assert.rejects(runSetup({ target: join(target, "missing"), log: quiet }), /does not exist/);
+});


### PR DESCRIPTION
## Outcome

Makes the reference distribution installable for end users: `scripts/setup.mjs` (exposed as the `rdlc-setup` bin, runnable via `npx github:aithinkers/requirements-dlc`) installs the generated Claude Code plugin into `.claude/plugins/rdlc/`, scaffolds a §47-defaults `requirements-project.yaml` and the §11 `rdlc/` space/engagement layout — idempotently, with user-modified files protected unless `--force` and a `--check` drift mode; package metadata (files/exports/bin) exposes every governed library as a subpath export and packs to 78 files / 73 kB; `docs/getting-started.md` walks install → first engagement → team workflow; README gains the install section.

Closes #32

## Traceability

- Requirement IDs: FEAT-013
- Specification sections: §11, §36, §47
- Conformance modules affected: Harness:Claude-Code (distribution surface)
- Traceability index updated: yes — FEAT-013 verified

## Gate evidence

- [x] Feature/requirement definition is complete and linked.
- [x] Implementation plan received the required review (K-DLC setup-installer parity).
- [x] Development stayed within issue scope.
- [x] Deterministic tests cover acceptance and failure criteria.
- [x] Final review considered correctness, security, and traceability.

Commands and results:

```text
npm test — 185 pass, 0 fail (install/idempotence/protect/--force/--check/missing-target)
npm pack --dry-run — requirements-dlc 0.1.0, 78 files, 72.8 kB (core, dist, installer, release statement only)
```

## Security, privacy, rights, and retention

The installer writes only the generated plugin, the manifest, and empty scaffold directories; it never executes target-project content, never overwrites modified files silently, and the scaffolded manifest declares external content untrusted with propose-only defaults.

## Compatibility, migration, and rollback

Additive. Rollback = revert; installed projects keep working (plugin files are self-contained).

## Release and documentation

After merge: v0.1.1 tag + release refresh so `npx github:aithinkers/requirements-dlc` resolves the installer from the default branch.
