### PR TITLE
fix: Claude Code command/agent discovery and marketplace install (#34) [FEAT-014]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,12 @@
+{
+  "name": "rdlc",
+  "owner": { "name": "AIThinkers", "url": "https://github.com/aithinkers" },
+  "plugins": [
+    {
+      "name": "rdlc",
+      "source": "./dist/claude-code",
+      "description": "Governed R-DLC requirements lifecycle: 26 /rdlc-* commands and 10 role agents.",
+      "version": "0.2.0"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ durable checkpoints.
 npx github:aithinkers/requirements-dlc
 ```
 
-installs the Claude Code plugin (26 `/rdlc-*` commands + 10 role agents), a
+installs the 26 `/rdlc-*` commands and 10 role agents into `.claude/commands/`
+and `.claude/agents/` (where Claude Code discovers them), plus a
 §47-defaults `requirements-project.yaml`, and the `rdlc/` engagement layout
 into your project — idempotently, without clobbering your edits. Then open
 the project in Claude Code and run `/rdlc-start`. Full walkthrough:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,12 +23,21 @@ codes: `0` success or up-to-date, `1` drift found or setup error, `2`
 completed but user-modified files were protected. It
 installs:
 
-- `.claude/plugins/rdlc/` — the Claude Code plugin: 26 `/rdlc-*` commands and
-  the ten §38 role agents, generated from the authored core and byte-exact
-  drift-protected
+- `.claude/commands/` and `.claude/agents/` — the 26 `/rdlc-*` commands and
+  ten §38 role agents, placed where Claude Code auto-discovers them
+  (generated from the authored core and byte-exact drift-protected)
 - `requirements-project.yaml` — a §47-defaults project manifest
   (files-authoritative, propose-only connectors, untrusted external content)
 - `rdlc/` — the §11 space/engagement layout
+
+Prefer the plugin manager instead? From Claude Code:
+
+```
+/plugin marketplace add aithinkers/requirements-dlc
+/plugin install rdlc@rdlc
+```
+
+(both surfaces ship the same generated files; pick one per project).
 
 ## First engagement
 

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -363,6 +363,25 @@
           "tests/governance/engagement.test.mjs"
         ]
       }
+    },
+    {
+      "id": "FEAT-014",
+      "title": "Fix Claude Code discovery — .claude/commands+agents install and marketplace manifest",
+      "issue": 34,
+      "specification_sections": [
+        "§36"
+      ],
+      "status": "verified",
+      "evidence": {
+        "implementation": [
+          "scripts/setup.mjs",
+          ".claude-plugin/marketplace.json",
+          "docs/getting-started.md"
+        ],
+        "tests": [
+          "tests/governance/engagement.test.mjs"
+        ]
+      }
     }
   ]
 }

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -13,7 +13,7 @@
  */
 
 import { createHash } from "node:crypto";
-import { mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import process from "node:process";
@@ -35,14 +35,14 @@ function parseArguments(argv) {
 const sha256 = (bytes) => createHash("sha256").update(bytes).digest("hex");
 
 async function listPluginFiles() {
+  // Claude Code discovers project commands in .claude/commands and agents in
+  // .claude/agents — NOT under .claude/plugins (issue #34). The plugin-shaped
+  // dist/claude-code tree remains available for `claude plugin install`.
   const base = join(packageRoot, "dist", "claude-code");
   const files = [];
-  for (const directory of ["commands", "agents", ".claude-plugin"]) {
+  for (const [directory, destination] of [["commands", join(".claude", "commands")], ["agents", join(".claude", "agents")]]) {
     for (const name of await readdir(join(base, directory))) {
-      files.push({
-        source: join(base, directory, name),
-        relative: join(".claude", "plugins", "rdlc", directory, name)
-      });
+      files.push({ source: join(base, directory, name), relative: join(destination, name) });
     }
   }
   return files;
@@ -141,6 +141,13 @@ export async function runSetup({ target, force = false, check = false, log = con
   }
 
   if (!check) {
+    // Migrate away the 0.1.1 layout Claude Code never discovered (issue #34).
+    const legacy = join(target, ".claude", "plugins", "rdlc");
+    try {
+      await stat(legacy);
+      await rm(legacy, { recursive: true });
+      results.migrated = legacy;
+    } catch { /* no legacy install */ }
     for (const directory of SCAFFOLD_DIRECTORIES) {
       const destination = join(target, directory);
       try {
@@ -158,6 +165,7 @@ export async function runSetup({ target, force = false, check = false, log = con
     log(results.drift.length === 0 ? "  up to date" : results.drift.map((entry) => `  drift: ${entry.file} (${entry.state})`).join("\n"));
   } else {
     log(`  installed: ${results.installed.length}, unchanged: ${results.skipped.length}, scaffolded: ${results.scaffolded.length}`);
+    if (results.migrated) log(`  migrated: removed undiscovered legacy install at ${results.migrated}`);
     for (const file of results.protected) {
       log(`  PROTECTED (user-modified, use --force to overwrite): ${file}`);
     }

--- a/tests/governance/engagement.test.mjs
+++ b/tests/governance/engagement.test.mjs
@@ -191,9 +191,9 @@ test("FEAT-013: setup installs the plugin and scaffold idempotently and protects
 
   const first = await runSetup({ target, log: quiet });
   assert.ok(first.installed.includes("requirements-project.yaml"));
-  assert.ok(first.installed.some((file) => file.endsWith(join("commands", "rdlc-start.md"))));
-  assert.ok(first.installed.some((file) => file.endsWith(join("agents", "rdlc-facilitator.md"))));
-  assert.ok(first.installed.some((file) => file.endsWith(join(".claude-plugin", "plugin.json"))));
+  assert.ok(first.installed.includes(join(".claude", "commands", "rdlc-start.md")), "commands land where Claude Code discovers them");
+  assert.ok(first.installed.includes(join(".claude", "agents", "rdlc-facilitator.md")), "agents land where Claude Code discovers them");
+  assert.ok(!first.installed.some((file) => file.includes(join(".claude", "plugins"))), "no undiscovered plugins/ path (issue #34)");
   assert.ok(first.scaffolded.includes("rdlc/spaces/main/engagements"));
   const manifest = await readFile(join(target, "requirements-project.yaml"), "utf8");
   assert.match(manifest, /authority_mode: files-authoritative/);
@@ -213,4 +213,28 @@ test("FEAT-013: setup installs the plugin and scaffold idempotently and protects
   const forced = await runSetup({ target, force: true, log: quiet });
   assert.deepEqual(forced.installed, ["requirements-project.yaml"]);
   await assert.rejects(runSetup({ target: join(target, "missing"), log: quiet }), /does not exist/);
+});
+
+test("FEAT-014: setup migrates the undiscovered 0.1.1 layout and the marketplace manifest resolves the plugin", async () => {
+  const { runSetup } = await import("../../scripts/setup.mjs");
+  const quiet = () => {};
+  const target = await mkdtemp(join(tmpdir(), "rdlc-migrate-"));
+  // Simulate a 0.1.1 install.
+  const legacy = join(target, ".claude", "plugins", "rdlc", "commands");
+  await (await import("node:fs/promises")).mkdir(legacy, { recursive: true });
+  await writeFile(join(legacy, "rdlc-start.md"), "legacy", "utf8");
+
+  const result = await runSetup({ target, log: quiet });
+  assert.match(result.migrated, /\.claude\/plugins\/rdlc$/);
+  await assert.rejects(readFile(join(legacy, "rdlc-start.md")), undefined, "legacy copy removed");
+  const discovered = await readFile(join(target, ".claude", "commands", "rdlc-start.md"), "utf8");
+  assert.match(discovered, /rdlc-start/);
+  const agents = await (await import("node:fs/promises")).readdir(join(target, ".claude", "agents"));
+  assert.equal(agents.length, 10);
+
+  const marketplace = JSON.parse(await readFile(".claude-plugin/marketplace.json", "utf8"));
+  assert.equal(marketplace.plugins[0].name, "rdlc");
+  assert.equal(marketplace.plugins[0].source, "./dist/claude-code");
+  const plugin = JSON.parse(await readFile("dist/claude-code/.claude-plugin/plugin.json", "utf8"));
+  assert.equal(plugin.name, "rdlc");
 });


### PR DESCRIPTION
## Outcome

Fixes the 0.1.1 distribution defect where installed users saw no commands or agents: the installer wrote to `.claude/plugins/rdlc/`, which Claude Code never discovers. Now: commands install to `.claude/commands/` and agents to `.claude/agents/` (project-scoped auto-discovery); a repository `.claude-plugin/marketplace.json` enables `/plugin marketplace add aithinkers/requirements-dlc` + `/plugin install rdlc@rdlc` as the plugin-manager path over the same generated `dist/claude-code` tree; re-running setup migrates away (and reports) a legacy 0.1.1 install; docs cover both paths.

Closes #34

## Traceability

- Requirement IDs: FEAT-014
- Specification sections: §36
- Conformance modules affected: Harness:Claude-Code
- Traceability index updated: yes — FEAT-014 verified

## Gate evidence

- [x] Feature/requirement definition is complete and linked.
- [x] Implementation plan received the required review (K-DLC precedent: `claude plugin install` over dist/claude-code).
- [x] Development stayed within issue scope.
- [x] Deterministic tests cover acceptance and failure criteria.
- [x] Final review considered correctness, security, and traceability.

Commands and results:

```text
npm test — 186 pass, 0 fail (discovered destinations asserted; no plugins/ path; legacy migration removes the dead copy; marketplace manifest resolves ./dist/claude-code)
```

## Security, privacy, rights, and retention

Migration removes only the exact legacy `.claude/plugins/rdlc` tree this installer created, and reports it. Idempotence/protection semantics unchanged.

## Compatibility, migration, and rollback

0.1.1 installs are migrated automatically on the next setup run. Rollback = revert.

## Release and documentation

After merge: tag v0.1.2 and refresh the release so `npx` installs the fixed layout.
