### PR TITLE
feat: connector configuration format and loader (#42) [FEAT-017]

### DIFF
--- a/core/lib/connector-config.mjs
+++ b/core/lib/connector-config.mjs
@@ -1,0 +1,168 @@
+/**
+ * Connector configuration loader (spec §11.1, §20.1, §22.2, §29).
+ *
+ * Reads `requirements-project.yaml` and each declared connector's versioned
+ * mapping file (`rdlc.connector-mapping/v0.2`) and yields ready-to-use
+ * objects: the JiraConnector field mapping, the estimation profile binding,
+ * the component binding, and per-artifact-type template mappings for
+ * TemplateCatalog.validateProviderItem / detectFormatDrift.
+ *
+ * Fails closed on every inconsistency (§7.2): unknown schemes, estimation or
+ * template fields absent from the mapped field list, duplicate issue types,
+ * unknown artifact types.
+ */
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import YAML from "yaml";
+
+import { SCHEMES, createProfile } from "./estimation.mjs";
+
+export class ConnectorConfigError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "ConnectorConfigError";
+  }
+}
+
+const WRITE_MODES = ["read-only", "propose", "approve-each-batch", "approved-automation"];
+
+/** Validate one mapping document (already parsed). */
+export function validateMapping(mapping, { catalogTypes = null } = {}) {
+  const failures = [];
+  if (mapping?.schema_version !== "rdlc.connector-mapping/v0.2") {
+    failures.push(`unknown mapping schema_version: ${mapping?.schema_version}`);
+    return failures;
+  }
+  for (const field of ["version", "provider", "project_key"]) {
+    if (!mapping[field]) failures.push(`mapping requires ${field}`);
+  }
+  if (!Array.isArray(mapping.fields) || mapping.fields.length === 0) {
+    failures.push("mapping requires a non-empty fields list (§29)");
+  }
+  const fieldSet = new Set(mapping.fields ?? []);
+
+  const estimation = mapping.estimation;
+  if (estimation) {
+    if (!SCHEMES.includes(estimation.scheme)) failures.push(`unknown estimation scheme: ${estimation.scheme} (§22.1)`);
+    if (!estimation.provider_field) failures.push("estimation requires provider_field (§22.2 item 11)");
+    else if (!fieldSet.has(estimation.provider_field)) {
+      failures.push(`estimation provider_field "${estimation.provider_field}" is not in the mapped fields list`);
+    }
+    if (!estimation.profile) failures.push("estimation requires the profile id it binds (§22.2)");
+    if (estimation.scheme !== "no-estimate" && (!Array.isArray(estimation.allowed_values) || estimation.allowed_values.length === 0)) {
+      failures.push("estimation requires allowed_values (§22.2 item 2)");
+    }
+  }
+
+  if (mapping.components) {
+    if (!mapping.components.provider_field) failures.push("components binding requires provider_field");
+    else if (!fieldSet.has(mapping.components.provider_field)) {
+      failures.push(`components provider_field "${mapping.components.provider_field}" is not in the mapped fields list`);
+    }
+    if (!["name", "id"].includes(mapping.components.match_by ?? "name")) {
+      failures.push(`components match_by must be name or id, not ${mapping.components.match_by}`);
+    }
+  }
+
+  const issueTypes = new Set();
+  for (const [artifactType, binding] of Object.entries(mapping.artifact_types ?? {})) {
+    if (catalogTypes && !catalogTypes.includes(artifactType)) {
+      failures.push(`artifact type "${artifactType}" has no template in the catalog (§20.1)`);
+    }
+    if (!binding.issue_type) failures.push(`artifact type "${artifactType}" requires its provider issue_type (§20.1)`);
+    else if (issueTypes.has(binding.issue_type)) {
+      failures.push(`issue type "${binding.issue_type}" is bound to more than one artifact type`);
+    } else {
+      issueTypes.add(binding.issue_type);
+    }
+    for (const [templateField, providerField] of Object.entries(binding.template_fields ?? {})) {
+      const head = String(providerField).split(".")[0];
+      if (!fieldSet.has(head)) {
+        failures.push(`artifact type "${artifactType}": template field "${templateField}" maps to "${providerField}", which is not in the mapped fields list`);
+      }
+    }
+  }
+  return failures;
+}
+
+/**
+ * Load the project's connector configuration. Returns one entry per declared
+ * connector: { id, provider, write_mode, connectorMapping, estimation,
+ * components, templateMappings }.
+ */
+export async function loadConnectorConfig(projectRoot, { catalogTypes = null, confirmers = [] } = {}) {
+  let manifest;
+  try {
+    manifest = YAML.parse(await readFile(join(projectRoot, "requirements-project.yaml"), "utf8"));
+  } catch (error) {
+    throw new ConnectorConfigError(`requirements-project.yaml cannot be read: ${error.message}`);
+  }
+  const declared = manifest?.connectors ?? [];
+  const results = [];
+  for (const connector of declared) {
+    for (const field of ["id", "provider", "mapping", "write_mode"]) {
+      if (!connector[field]) throw new ConnectorConfigError(`connector declaration requires ${field} (§11.1)`);
+    }
+    if (!WRITE_MODES.includes(connector.write_mode)) {
+      throw new ConnectorConfigError(`unknown write mode for ${connector.id}: ${connector.write_mode} (§29.2)`);
+    }
+    let mapping;
+    try {
+      mapping = YAML.parse(await readFile(join(projectRoot, connector.mapping), "utf8"));
+    } catch (error) {
+      throw new ConnectorConfigError(`mapping file for ${connector.id} cannot be read: ${connector.mapping}: ${error.message}`);
+    }
+    const failures = validateMapping(mapping, { catalogTypes });
+    if (failures.length > 0) {
+      throw new ConnectorConfigError(`mapping ${connector.mapping} is invalid:\n  - ${failures.join("\n  - ")}`);
+    }
+    if (mapping.provider !== connector.provider) {
+      throw new ConnectorConfigError(`mapping provider "${mapping.provider}" does not match connector "${connector.provider}"`);
+    }
+
+    // Ready-to-use JiraConnector mapping (§29/§30).
+    const connectorMapping = { version: mapping.version, projectKey: mapping.project_key, fields: [...mapping.fields] };
+
+    // Ready-to-use estimation profile (§22): confirmation stays with the
+    // configured confirmers; AI values remain suggestions.
+    const estimation = mapping.estimation
+      ? {
+          provider_field: mapping.estimation.provider_field,
+          profile: createProfile({
+            id: mapping.estimation.profile,
+            scheme: mapping.estimation.scheme,
+            allowedValues: mapping.estimation.allowed_values ?? null,
+            meaning: mapping.estimation.meaning ?? "as configured by the team (§22.2 item 3)",
+            aiSuggestionsAllowed: mapping.estimation.allow_ai_suggestions ?? true,
+            confirmers: mapping.estimation.confirmers ?? confirmers
+          })
+        }
+      : null;
+
+    // Per-artifact-type template mappings for validateProviderItem/drift (§20.1).
+    const templateMappings = Object.fromEntries(
+      Object.entries(mapping.artifact_types ?? {}).map(([artifactType, binding]) => [
+        artifactType,
+        {
+          version: `${mapping.version}/${artifactType}`,
+          artifact_type: artifactType,
+          issue_type: binding.issue_type,
+          fields: { ...(binding.template_fields ?? {}) }
+        }
+      ])
+    );
+
+    results.push({
+      id: connector.id,
+      provider: connector.provider,
+      write_mode: connector.write_mode,
+      connectorMapping,
+      estimation,
+      components: mapping.components ? { ...mapping.components } : null,
+      templateMappings
+    });
+  }
+  return results;
+}

--- a/core/lib/connector-config.mjs
+++ b/core/lib/connector-config.mjs
@@ -13,7 +13,7 @@
  */
 
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 
 import YAML from "yaml";
 
@@ -101,6 +101,7 @@ export async function loadConnectorConfig(projectRoot, { catalogTypes = null, co
   }
   const declared = manifest?.connectors ?? [];
   const results = [];
+  const seenIds = new Set();
   for (const connector of declared) {
     for (const field of ["id", "provider", "mapping", "write_mode"]) {
       if (!connector[field]) throw new ConnectorConfigError(`connector declaration requires ${field} (§11.1)`);
@@ -108,11 +109,26 @@ export async function loadConnectorConfig(projectRoot, { catalogTypes = null, co
     if (!WRITE_MODES.includes(connector.write_mode)) {
       throw new ConnectorConfigError(`unknown write mode for ${connector.id}: ${connector.write_mode} (§29.2)`);
     }
+    if (seenIds.has(connector.id)) throw new ConnectorConfigError(`duplicate connector id: ${connector.id}`);
+    seenIds.add(connector.id);
+    // Mapping paths are confined to the project root (§7.2 fail closed);
+    // foreign file content is never echoed into errors.
+    const mappingPath = resolve(projectRoot, connector.mapping);
+    const confined = relative(resolve(projectRoot), mappingPath);
+    if (isAbsolute(connector.mapping) || confined.startsWith("..") || isAbsolute(confined)) {
+      throw new ConnectorConfigError(`mapping path for ${connector.id} escapes the project root: ${connector.mapping}`);
+    }
+    let raw;
+    try {
+      raw = await readFile(mappingPath, "utf8");
+    } catch {
+      throw new ConnectorConfigError(`mapping file for ${connector.id} cannot be read: ${connector.mapping}`);
+    }
     let mapping;
     try {
-      mapping = YAML.parse(await readFile(join(projectRoot, connector.mapping), "utf8"));
-    } catch (error) {
-      throw new ConnectorConfigError(`mapping file for ${connector.id} cannot be read: ${connector.mapping}: ${error.message}`);
+      mapping = YAML.parse(raw);
+    } catch {
+      throw new ConnectorConfigError(`mapping file for ${connector.id} is not valid YAML: ${connector.mapping}`);
     }
     const failures = validateMapping(mapping, { catalogTypes });
     if (failures.length > 0) {
@@ -127,8 +143,10 @@ export async function loadConnectorConfig(projectRoot, { catalogTypes = null, co
 
     // Ready-to-use estimation profile (§22): confirmation stays with the
     // configured confirmers; AI values remain suggestions.
-    const estimation = mapping.estimation
-      ? {
+    let estimation = null;
+    if (mapping.estimation) {
+      try {
+        estimation = {
           provider_field: mapping.estimation.provider_field,
           profile: createProfile({
             id: mapping.estimation.profile,
@@ -136,10 +154,13 @@ export async function loadConnectorConfig(projectRoot, { catalogTypes = null, co
             allowedValues: mapping.estimation.allowed_values ?? null,
             meaning: mapping.estimation.meaning ?? "as configured by the team (§22.2 item 3)",
             aiSuggestionsAllowed: mapping.estimation.allow_ai_suggestions ?? true,
-            confirmers: mapping.estimation.confirmers ?? confirmers
+            confirmers: (mapping.estimation.confirmers?.length ? mapping.estimation.confirmers : confirmers)
           })
-        }
-      : null;
+        };
+      } catch (error) {
+        throw new ConnectorConfigError(`connector ${connector.id} (${connector.mapping}): estimation configuration invalid: ${error.message}`);
+      }
+    }
 
     // Per-artifact-type template mappings for validateProviderItem/drift (§20.1).
     const templateMappings = Object.fromEntries(

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -107,6 +107,41 @@ and the provider field; unmapped required fields surface as mapping gaps;
 externally edited items that no longer follow the format become RDLC-FMT-003
 review findings with dispositions — never silent repair.
 
+## Configuring a connector (fields, components, story points)
+
+Setup scaffolds `config/connectors/jira-example.yaml`. Copy it, fill in your
+project key, fields, and bindings, and declare it in
+`requirements-project.yaml`:
+
+```yaml
+connectors:
+  - id: delivery-jira
+    provider: jira
+    mapping: config/connectors/jira-com.yaml
+    write_mode: propose        # upgrade to approve-each-batch when ready to write
+```
+
+The mapping file binds everything in one place:
+
+- **fields** — the provider fields R-DLC reads, diffs, and read-back-verifies
+- **estimation** — which Jira field holds story points, the scheme and scale,
+  and who may confirm (AI values stay `suggested`; no auto conversion)
+- **components** — the provider field matched against the component registry
+- **artifact_types** — template ↔ issue-type ↔ field bindings per level
+  (story, epic, …) powering `validateProviderItem` and format-drift detection
+
+Load it in one call:
+
+```js
+import { loadConnectorConfig } from "requirements-dlc/connector-config";
+const [jira] = await loadConnectorConfig(projectRoot, { catalogTypes: catalog.types() });
+new JiraConnector({ transport, mapping: jira.connectorMapping, writeMode: jira.write_mode });
+catalog.detectFormatDrift(polledUpdates, jira.templateMappings.story);
+```
+
+Invalid configs fail closed with named reasons (unknown scheme, estimation
+field missing from `fields`, template field unmapped, duplicate issue types).
+
 ## Working as a team
 
 Declare advisory scope with `/rdlc-claim` (overlaps notify, never block),

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -447,6 +447,28 @@
           "tests/governance/template-catalog.test.mjs"
         ]
       }
+    },
+    {
+      "id": "FEAT-017",
+      "title": "Connector configuration format and loader",
+      "issue": 42,
+      "specification_sections": [
+        "§11.1",
+        "§20.1",
+        "§22.2",
+        "§29"
+      ],
+      "status": "verified",
+      "evidence": {
+        "implementation": [
+          "core/lib/connector-config.mjs",
+          "scripts/setup.mjs",
+          "docs/getting-started.md"
+        ],
+        "tests": [
+          "tests/governance/connector-config.test.mjs"
+        ]
+      }
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "./engagement": "./core/lib/engagement.mjs",
     "./connectors/jira": "./core/connectors/jira/index.mjs",
     "./schemas": "./core/schemas/v0.2/index.mjs",
-    "./template-catalog": "./core/lib/template-catalog.mjs"
+    "./template-catalog": "./core/lib/template-catalog.mjs",
+    "./connector-config": "./core/lib/connector-config.mjs"
   }
 }

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -102,6 +102,11 @@ estimation:
   allow_ai_suggestions: true
   confirmation_required: true
 
+# Declare connectors here and describe each in its mapping file, e.g.:
+#   - id: delivery-jira
+#     provider: jira
+#     mapping: config/connectors/jira-example.yaml
+#     write_mode: propose
 connectors: []
 
 security:
@@ -109,6 +114,35 @@ security:
   secrets_provider: environment
 `;
 }
+
+const EXAMPLE_MAPPING = `schema_version: rdlc.connector-mapping/v0.2
+version: jira-example/v1
+provider: jira
+project_key: COM
+fields: [summary, description, status, components, customfield_10016]
+
+estimation:
+  profile: team-story-points
+  provider_field: customfield_10016
+  scheme: story-points
+  allowed_values: [1, 2, 3, 5, 8, 13]
+  # confirmers: [urn:uuid:...]        # who may confirm estimates (§22.2)
+
+components:
+  provider_field: components
+  match_by: name
+
+artifact_types:
+  story:
+    issue_type: Story
+    template_fields:
+      statement: summary
+      acceptance_criteria: description
+  epic:
+    issue_type: Epic
+    template_fields:
+      outcome: summary
+`;
 
 const SCAFFOLD_DIRECTORIES = [
   "rdlc/spaces/main/policy",
@@ -142,6 +176,7 @@ export async function runSetup({ target, tool = "claude-code", force = false, ch
   const plan = await listPluginFiles(tool);
   const projectId = basename(resolve(target)) || "rdlc-project";
   plan.push({ content: projectManifest(projectId), relative: "requirements-project.yaml" });
+  plan.push({ content: EXAMPLE_MAPPING, relative: join("config", "connectors", "jira-example.yaml") });
 
   for (const entry of plan) {
     const destination = join(target, entry.relative);

--- a/tests/governance/connector-config.test.mjs
+++ b/tests/governance/connector-config.test.mjs
@@ -106,3 +106,25 @@ test("FEAT-017: setup scaffolds the example mapping and a project without connec
   const configs = await loadConnectorConfig(target);
   assert.deepEqual(configs, [], "empty connectors list is valid");
 });
+
+test("FEAT-017: mapping paths are confined to the project root; errors carry config context (review MEDIUMs)", async () => {
+  const escape = await projectWith(GOOD_MAPPING, `connectors:\n  - id: x\n    provider: jira\n    mapping: ../../../../etc/hosts\n    write_mode: propose\n`);
+  await assert.rejects(loadConnectorConfig(escape), /escapes the project root/);
+  const absolute = await projectWith(GOOD_MAPPING, `connectors:\n  - id: x\n    provider: jira\n    mapping: /etc/hosts\n    write_mode: propose\n`);
+  await assert.rejects(loadConnectorConfig(absolute), /escapes the project root/);
+
+  // No confirmers anywhere: a config-scoped error naming connector and file.
+  const noConfirmers = await projectWith(GOOD_MAPPING);
+  await assert.rejects(
+    loadConnectorConfig(noConfirmers, { catalogTypes: catalog.types() }),
+    (error) => error instanceof ConnectorConfigError && /delivery-jira/.test(error.message) && /jira-com.yaml/.test(error.message) && /confirms estimates/.test(error.message)
+  );
+
+  // Duplicate connector ids fail closed.
+  const duplicate = await projectWith(GOOD_MAPPING, `connectors:\n  - id: a\n    provider: jira\n    mapping: config/connectors/jira-com.yaml\n    write_mode: propose\n  - id: a\n    provider: jira\n    mapping: config/connectors/jira-com.yaml\n    write_mode: propose\n`);
+  await assert.rejects(loadConnectorConfig(duplicate, { catalogTypes: catalog.types(), confirmers: [confirmer] }), /duplicate connector id/);
+
+  // Unparseable YAML is reported as such, without echoing content.
+  const badYaml = await projectWith("{{{{not yaml");
+  await assert.rejects(loadConnectorConfig(badYaml), (error) => /not valid YAML/.test(error.message) && !/not yaml/.test(error.message));
+});

--- a/tests/governance/connector-config.test.mjs
+++ b/tests/governance/connector-config.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { ConnectorConfigError, loadConnectorConfig, validateMapping } from "../../core/lib/connector-config.mjs";
+import { loadCatalog } from "../../core/lib/template-catalog.mjs";
+import { suggestEstimate } from "../../core/lib/estimation.mjs";
+import { mintIdentity } from "../../core/lib/identity.mjs";
+
+const catalog = await loadCatalog();
+const confirmer = mintIdentity();
+
+const GOOD_MAPPING = `schema_version: rdlc.connector-mapping/v0.2
+version: jira-com/v1
+provider: jira
+project_key: COM
+fields: [summary, description, status, components, customfield_10016, customfield_ac, customfield_reqs]
+estimation:
+  profile: team-story-points
+  provider_field: customfield_10016
+  scheme: story-points
+  allowed_values: [1, 2, 3, 5, 8, 13]
+components:
+  provider_field: components
+  match_by: name
+artifact_types:
+  story:
+    issue_type: Story
+    template_fields:
+      statement: summary
+      acceptance_criteria: customfield_ac
+      requirements_covered: customfield_reqs
+  epic:
+    issue_type: Epic
+    template_fields:
+      outcome: summary
+`;
+
+async function projectWith(mappingText, connectors = null) {
+  const root = await mkdtemp(join(tmpdir(), "rdlc-cfg-"));
+  const declaration = connectors ?? `connectors:
+  - id: delivery-jira
+    provider: jira
+    mapping: config/connectors/jira-com.yaml
+    write_mode: propose
+`;
+  await writeFile(join(root, "requirements-project.yaml"), `schema_version: rdlc.project/v0.2\nproject:\n  id: p\n${declaration}`, "utf8");
+  await mkdir(join(root, "config", "connectors"), { recursive: true });
+  await writeFile(join(root, "config", "connectors", "jira-com.yaml"), mappingText, "utf8");
+  return root;
+}
+
+test("FEAT-017: a valid config loads into ready-to-use connector, estimation, and template objects", async () => {
+  const root = await projectWith(GOOD_MAPPING);
+  const [config] = await loadConnectorConfig(root, { catalogTypes: catalog.types(), confirmers: [confirmer] });
+  assert.equal(config.id, "delivery-jira");
+  assert.equal(config.write_mode, "propose");
+  // JiraConnector-ready mapping.
+  assert.deepEqual(config.connectorMapping, { version: "jira-com/v1", projectKey: "COM", fields: ["summary", "description", "status", "components", "customfield_10016", "customfield_ac", "customfield_reqs"] });
+  // Estimation profile is live: suggestions validate against the configured scale.
+  const suggestion = suggestEstimate(config.estimation.profile, { artifact: mintIdentity(), value: 5, method: "reference", rationale: "similar", at: "t" });
+  assert.equal(suggestion.status, "suggested");
+  assert.throws(() => suggestEstimate(config.estimation.profile, { artifact: "a", value: 4, method: "m", rationale: "r", at: "t" }), /outside the .* scale/);
+  assert.equal(config.estimation.provider_field, "customfield_10016");
+  // Components binding.
+  assert.deepEqual(config.components, { provider_field: "components", match_by: "name" });
+  // Template mapping feeds validateProviderItem directly.
+  const result = catalog.validateProviderItem(
+    { item_id: "COM-9", revision: "r1", fields: { summary: "s" } },
+    config.templateMappings.story
+  );
+  assert.equal(result.valid, false);
+  assert.ok(result.findings.some((finding) => finding.template_field === "acceptance_criteria" && finding.provider_field === "customfield_ac"));
+});
+
+test("FEAT-017: invalid configs fail closed with explainable messages", async () => {
+  const badScheme = GOOD_MAPPING.replace("scheme: story-points", "scheme: vibes");
+  assert.ok(validateMapping((await import("yaml")).default.parse(badScheme)).some((failure) => /unknown estimation scheme/.test(failure)));
+
+  const unmappedEstimation = GOOD_MAPPING.replace("customfield_10016, ", "");
+  assert.ok(validateMapping((await import("yaml")).default.parse(unmappedEstimation)).some((failure) => /not in the mapped fields list/.test(failure)));
+
+  const unknownType = GOOD_MAPPING.replace("  epic:", "  saga:");
+  assert.ok(validateMapping((await import("yaml")).default.parse(unknownType), { catalogTypes: catalog.types() }).some((failure) => /no template in the catalog/.test(failure)));
+
+  const duplicateIssueType = GOOD_MAPPING.replace("issue_type: Epic", "issue_type: Story");
+  assert.ok(validateMapping((await import("yaml")).default.parse(duplicateIssueType)).some((failure) => /bound to more than one artifact type/.test(failure)));
+
+  const root = await projectWith(badScheme);
+  await assert.rejects(loadConnectorConfig(root, { catalogTypes: catalog.types() }), ConnectorConfigError);
+  const badMode = await projectWith(GOOD_MAPPING, `connectors:\n  - id: x\n    provider: jira\n    mapping: config/connectors/jira-com.yaml\n    write_mode: yolo\n`);
+  await assert.rejects(loadConnectorConfig(badMode), /unknown write mode/);
+  const providerMismatch = await projectWith(GOOD_MAPPING.replace("provider: jira", "provider: github"));
+  await assert.rejects(loadConnectorConfig(providerMismatch, { catalogTypes: catalog.types() }), /does not match connector/);
+});
+
+test("FEAT-017: setup scaffolds the example mapping and a project without connectors loads cleanly", async () => {
+  const { runSetup } = await import("../../scripts/setup.mjs");
+  const target = await mkdtemp(join(tmpdir(), "rdlc-cfg-setup-"));
+  await runSetup({ target, log: () => {} });
+  const example = await (await import("node:fs/promises")).readFile(join(target, "config", "connectors", "jira-example.yaml"), "utf8");
+  assert.match(example, /rdlc.connector-mapping\/v0.2/);
+  assert.match(example, /story-points/);
+  const configs = await loadConnectorConfig(target);
+  assert.deepEqual(configs, [], "empty connectors list is valid");
+});


### PR DESCRIPTION
## Outcome

Connector configuration becomes a first-class documented format: `rdlc.connector-mapping/v0.2` YAML binds provider identity, mapped fields, estimation (profile, provider story-points field, scheme, scale, confirmers), components, and per-artifact-type template↔issue-type↔field mappings in one file. `loadConnectorConfig(projectRoot)` reads `requirements-project.yaml` + mapping files, fails closed on every inconsistency (unknown scheme, estimation/template fields absent from the field list, duplicate issue types, unknown artifact types, provider/write-mode mismatches), and yields ready-to-use objects for JiraConnector, `suggestEstimate`/`confirmEstimate`, and `validateProviderItem`/`detectFormatDrift` with zero glue. Setup scaffolds `config/connectors/jira-example.yaml`; getting-started documents the full flow; new export `requirements-dlc/connector-config`.

Closes #42

## Traceability

- Requirement IDs: FEAT-017
- Specification sections: §11.1, §20.1, §22.2, §29
- Conformance modules affected: Connected:Jira-Cloud-Company-Managed, Planning
- Traceability index updated: yes — FEAT-017 verified

## Gate evidence

- [x] Feature/requirement definition is complete and linked.
- [x] Implementation plan received the required review.
- [x] Development stayed within issue scope.
- [x] Deterministic tests cover acceptance and failure criteria.
- [x] Final review considered correctness, security, and traceability.

Commands and results:

```text
npm test — 199 pass, 0 fail (valid config → live estimation profile validating the configured scale, JiraConnector-ready mapping, template mapping feeding two-sided findings; fail-closed on bad scheme/unmapped fields/unknown types/duplicate issue types/bad write mode/provider mismatch; scaffolded example loads)
```

## Security, privacy, rights, and retention

Config loading is fail-closed and side-effect-free; no credentials in mapping files (secrets stay in the environment per §11.1); write modes validated against §29.2.

## Compatibility, migration, and rollback

Additive; projects with `connectors: []` are unaffected. Rollback = revert.

## Release and documentation

After merge: tag v0.1.6 and refresh the release.
