### PR TITLE
feat: human-first runtime — sensors, hooks, memory, guides (#48) [FEAT-020]

### DIFF
--- a/core/hooks/guard.mjs
+++ b/core/hooks/guard.mjs
@@ -12,6 +12,9 @@ process.stdin.on("data", (chunk) => { input += chunk; });
 process.stdin.on("end", () => {
   let path = "";
   try { path = JSON.parse(input)?.tool_input?.file_path ?? ""; } catch { /* no path, allow */ }
+  // Normalize before matching: backslashes, duplicate slashes, and ./ hops
+  // must not slip past the rules (defense in depth).
+  path = String(path).replace(/\\/g, "/").replace(/\/\.\//g, "/").replace(/\/{2,}/g, "/");
   const rules = [
     [/rdlc\/(spaces\/[^/]+\/engagements\/[^/]+\/)?(approvals|baselines)\//,
       "Approvals and baselines are evidence — editing them by hand would break the audit trail. Use /rdlc-approve or /rdlc-baseline instead."],

--- a/core/hooks/guard.mjs
+++ b/core/hooks/guard.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * R-DLC write guard (PreToolUse hook for Write|Edit). Dependency-free.
+ *
+ * Approvals, baselines, and the reference library only change through their
+ * governed commands — a direct file edit would break the evidence chain.
+ * The message explains that in plain language; exit 2 blocks the edit.
+ */
+
+let input = "";
+process.stdin.on("data", (chunk) => { input += chunk; });
+process.stdin.on("end", () => {
+  let path = "";
+  try { path = JSON.parse(input)?.tool_input?.file_path ?? ""; } catch { /* no path, allow */ }
+  const rules = [
+    [/rdlc\/(spaces\/[^/]+\/engagements\/[^/]+\/)?(approvals|baselines)\//,
+      "Approvals and baselines are evidence — editing them by hand would break the audit trail. Use /rdlc-approve or /rdlc-baseline instead."],
+    [/rdlc\/reference\//,
+      "The rdlc/reference files are the shared playbook installed by R-DLC. To change how the workflow behaves, change project policy or rerun setup — direct edits here get overwritten on upgrade."],
+    [/rdlc\/\.install-manifest\.json$/,
+      "This file is R-DLC's record of what it installed. It maintains itself."]
+  ];
+  for (const [pattern, message] of rules) {
+    if (pattern.test(path)) {
+      console.error(message);
+      process.exit(2);
+    }
+  }
+  process.exit(0);
+});

--- a/core/hooks/orient.mjs
+++ b/core/hooks/orient.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * R-DLC session orientation (SessionStart hook). Dependency-free: prints one
+ * friendly line about where the engagement stands so a returning BA/PO knows
+ * exactly where they left off. Never blocks the session.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+function scalar(text, key) {
+  const match = text.match(new RegExp(`^${key}:\\s*(.+)$`, "m"));
+  return match ? match[1].trim().replace(/^["']|["']$/g, "") : null;
+}
+
+try {
+  const base = join(process.cwd(), "rdlc", "spaces");
+  const found = [];
+  for (const space of readdirSync(base)) {
+    const engagements = join(base, space, "engagements");
+    let ids = [];
+    try { ids = readdirSync(engagements); } catch { continue; }
+    for (const id of ids) {
+      try {
+        const text = readFileSync(join(engagements, id, "rdlc-state.yaml"), "utf8");
+        found.push({
+          scope: scalar(text, "scope"),
+          stage: scalar(text, "active_stage"),
+          next: scalar(text, "next_action"),
+          updated: scalar(text, "updated_at")
+        });
+      } catch { /* unreadable state surfaces via /rdlc-status */ }
+    }
+  }
+  if (found.length === 0) {
+    console.log("R-DLC is set up here but no engagement has started — /rdlc-start begins one.");
+  } else {
+    const latest = found.sort((a, b) => String(b.updated).localeCompare(String(a.updated)))[0];
+    console.log(`R-DLC: ${found.length > 1 ? `${found.length} engagements; latest` : "engagement"} at stage "${latest.stage}" (${latest.scope} scope). Next: ${latest.next ?? "/rdlc-status"}`);
+  }
+} catch {
+  // No rdlc/ here — stay silent; this project may not use R-DLC.
+}
+process.exit(0);

--- a/core/hooks/orient.mjs
+++ b/core/hooks/orient.mjs
@@ -36,7 +36,12 @@ try {
     console.log("R-DLC is set up here but no engagement has started — /rdlc-start begins one.");
   } else {
     const latest = found.sort((a, b) => String(b.updated).localeCompare(String(a.updated)))[0];
-    console.log(`R-DLC: ${found.length > 1 ? `${found.length} engagements; latest` : "engagement"} at stage "${latest.stage}" (${latest.scope} scope). Next: ${latest.next ?? "/rdlc-status"}`);
+    const clean = (value) => value && /^[\w./ :-]{1,80}$/.test(value) ? value : null;
+    if (clean(latest.stage) && clean(latest.scope)) {
+      console.log(`R-DLC: ${found.length > 1 ? `${found.length} engagements; latest` : "engagement"} at stage "${clean(latest.stage)}" (${clean(latest.scope)} scope). Next: ${clean(latest.next) ?? "/rdlc-status"}`);
+    } else {
+      console.log("R-DLC: an engagement exists here — /rdlc-status has the details.");
+    }
   }
 } catch {
   // No rdlc/ here — stay silent; this project may not use R-DLC.

--- a/core/lib/sensors.mjs
+++ b/core/lib/sensors.mjs
@@ -66,7 +66,7 @@ export const SENSORS = {
     return broken.length === 0
       ? result("schema", true, "All stored records are well-formed.")
       : result("schema", false,
-          `${plural(broken.length, "record")} in this project can't be read reliably — work built on them may be lost or wrong.`,
+          `${plural(broken.length, "record")} in this project can't be used reliably until repaired — nothing has been deleted.`,
           { next: "/rdlc-doctor", details: broken });
   },
 

--- a/core/lib/sensors.mjs
+++ b/core/lib/sensors.mjs
@@ -1,0 +1,182 @@
+/**
+ * Stage sensors with human-first reporting (§15, §42).
+ *
+ * Each sensor wraps the tested engine and answers three questions in plain
+ * language: is anything wrong, what does it mean for the work, and which
+ * command fixes it. Rule codes and stack traces stay in `details` for
+ * engineers; the `headline` is written for BAs, POs, and release managers.
+ */
+
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+import YAML from "yaml";
+
+import { detectCycles } from "./promotion.mjs";
+import { loadCatalog } from "./template-catalog.mjs";
+import { createValidator, validateRecord } from "../schemas/v0.2/index.mjs";
+
+/** One sensor result, written for humans first. */
+function result(sensor, ok, headline, { next = null, details = [] } = {}) {
+  return { sensor, ok, headline, next_command: next, details };
+}
+
+async function loadArtifacts(projectRoot) {
+  const artifacts = [];
+  const base = join(projectRoot, "rdlc", "spaces");
+  let spaces = [];
+  try { spaces = await readdir(base); } catch { return artifacts; }
+  for (const space of spaces) {
+    let engagements = [];
+    try { engagements = await readdir(join(base, space, "engagements")); } catch { continue; }
+    for (const engagement of engagements) {
+      const artifactRoot = join(base, space, "engagements", engagement, "artifacts");
+      let kinds = [];
+      try { kinds = await readdir(artifactRoot); } catch { continue; }
+      for (const kind of kinds) {
+        let files = [];
+        try { files = await readdir(join(artifactRoot, kind)); } catch { continue; }
+        for (const file of files.filter((name) => /\.(ya?ml|json)$/.test(name))) {
+          try {
+            const text = await readFile(join(artifactRoot, kind, file), "utf8");
+            artifacts.push({ file: join(kind, file), record: YAML.parse(text) });
+          } catch {
+            artifacts.push({ file: join(kind, file), unreadable: true });
+          }
+        }
+      }
+    }
+  }
+  return artifacts;
+}
+
+const plural = (n, word) => `${n} ${word}${n === 1 ? "" : "s"}`;
+
+export const SENSORS = {
+  /** Every stored artifact matches its schema. */
+  async schema(context) {
+    const broken = [];
+    const ajv = await createValidator();
+    for (const entry of context.artifacts) {
+      if (entry.unreadable) { broken.push({ file: entry.file, reason: "file cannot be read" }); continue; }
+      if (!entry.record?.schema_version) continue;
+      const { valid, failures } = await validateRecord(entry.record, ajv);
+      if (!valid) broken.push({ file: entry.file, reason: failures[0] });
+    }
+    return broken.length === 0
+      ? result("schema", true, "All stored records are well-formed.")
+      : result("schema", false,
+          `${plural(broken.length, "record")} in this project can't be read reliably — work built on them may be lost or wrong.`,
+          { next: "/rdlc-doctor", details: broken });
+  },
+
+  /** Every typed artifact carries its template's expected elements. */
+  async "template-catalog"(context) {
+    const catalog = await loadCatalog();
+    const known = new Set(catalog.types());
+    const gaps = [];
+    for (const entry of context.artifacts) {
+      const record = entry.record;
+      if (!record?.type || !known.has(record.type)) continue;
+      const failures = catalog.validateArtifact(record);
+      if (failures.length > 0) gaps.push({ file: entry.file, title: record.title ?? record.display_id ?? entry.file, missing: failures });
+    }
+    if (gaps.length === 0) return result("template-catalog", true, "Every requirement and story has its expected content.");
+    const example = gaps[0];
+    return result("template-catalog", false,
+      `${plural(gaps.length, "item")} ${gaps.length === 1 ? "is" : "are"} missing expected content — e.g. "${example.title}" (${example.missing[0].replace("required field missing: ", "no ").replaceAll("_", " ")}). Incomplete items will be held at the promotion gate.`,
+      { next: "/rdlc-draft", details: gaps });
+  },
+
+  /** No hard dependency loops. */
+  async cycles(context) {
+    const edges = [];
+    for (const entry of context.artifacts) {
+      for (const relationship of entry.record?.relationships ?? []) {
+        if (relationship.type === "depends-on") edges.push({ source: entry.record.id, target: relationship.target });
+      }
+    }
+    const cycles = detectCycles(edges);
+    return cycles.length === 0
+      ? result("cycles", true, "No circular dependencies — the work can be sequenced.")
+      : result("cycles", false,
+          `${plural(cycles.length, "dependency loop")} found — the items in each loop wait on each other, so none of them can start. Someone needs to break the loop.`,
+          { next: "/rdlc-dependencies", details: cycles.map((cycle) => ({ loop: cycle })) });
+  },
+
+  /** Engagement state is healthy and resumable. */
+  async state(context) {
+    const { loadEngagement } = await import("./engagement.mjs");
+    const base = join(context.projectRoot, "rdlc", "spaces");
+    const engagements = [];
+    let spaces = [];
+    try { spaces = await readdir(base); } catch { /* none yet */ }
+    for (const space of spaces) {
+      let ids = [];
+      try { ids = await readdir(join(base, space, "engagements")); } catch { continue; }
+      for (const id of ids) {
+        const directory = join(base, space, "engagements", id);
+        try {
+          await readFile(join(directory, "rdlc-state.yaml"));
+        } catch { continue; }
+        try {
+          const { state } = await loadEngagement(directory);
+          engagements.push({ id, next: state.next_action, uncertain: state.uncertain_writes?.length ?? 0 });
+        } catch (error) {
+          return result("state", false,
+            "An engagement's saved progress doesn't match its safety record — it was probably interrupted mid-save. Resume it to recover safely; don't edit the files by hand.",
+            { next: "/rdlc-start", details: [{ engagement: id, error: error.message }] });
+        }
+      }
+    }
+    if (engagements.length === 0) return result("state", true, "No engagement started yet.", { next: "/rdlc-start" });
+    const uncertain = engagements.filter((entry) => entry.uncertain > 0);
+    if (uncertain.length > 0) {
+      return result("state", false,
+        `${plural(uncertain.reduce((sum, entry) => sum + entry.uncertain, 0), "tracker write")} finished with an unknown outcome — the tracker may or may not have the change. Run a sync to reconcile before writing anything else.`,
+        { next: "/rdlc-sync", details: uncertain });
+    }
+    return result("state", true, `${plural(engagements.length, "engagement")} healthy. Next: ${engagements[0].next}`);
+  },
+
+  /** Connector configuration is valid, when declared. */
+  async connectors(context) {
+    const { loadConnectorConfig } = await import("./connector-config.mjs");
+    const catalog = await loadCatalog();
+    try {
+      const configs = await loadConnectorConfig(context.projectRoot, { catalogTypes: catalog.types() });
+      if (configs.length === 0) return result("connectors", true, "No tracker connected (that's fine — connect one anytime).", { next: "/rdlc-setup-connector" });
+      return result("connectors", true, `${plural(configs.length, "tracker connection")} configured and valid (${configs.map((config) => config.id).join(", ")}).`);
+    } catch (error) {
+      return result("connectors", false,
+        "A tracker connection is configured but its settings don't add up — syncing would fail. The setup assistant can fix it.",
+        { next: "/rdlc-setup-connector", details: [{ error: error.message }] });
+    }
+  }
+};
+
+/**
+ * Run the named sensors (default: all) against a project. Returns results
+ * plus a one-paragraph plain-language summary.
+ */
+export async function runSensors(projectRoot, { names = Object.keys(SENSORS) } = {}) {
+  const context = { projectRoot, artifacts: await loadArtifacts(projectRoot) };
+  const results = [];
+  for (const name of names) {
+    const sensor = SENSORS[name];
+    if (!sensor) {
+      results.push(result(name, false, `Unknown check "${name}" — this is a configuration mistake, not a problem with your work.`, { next: "/rdlc-doctor" }));
+      continue;
+    }
+    try {
+      results.push(await sensor(context));
+    } catch (error) {
+      results.push(result(name, false, `The "${name}" check itself failed to run — your work is untouched.`, { next: "/rdlc-doctor", details: [{ error: error.message }] }));
+    }
+  }
+  const problems = results.filter((entry) => !entry.ok);
+  const summary = problems.length === 0
+    ? "Everything checks out."
+    : `${plural(problems.length, "thing")} need${problems.length === 1 ? "s" : ""} attention: ${problems.map((entry) => entry.headline.split(" — ")[0]).join("; ")}.`;
+  return { results, summary, ok: problems.length === 0 };
+}

--- a/core/memory/organization.md
+++ b/core/memory/organization.md
@@ -1,0 +1,19 @@
+# Organization memory
+
+R-DLC reads this at the start of every session so agents follow your
+organization's rules without being reminded.
+
+## Approval culture
+
+<!-- Who must approve what, in your words. Example:
+"Compliance signs off on anything touching customer data. Product owns scope." -->
+
+## Locked policies
+
+<!-- Rules no project may weaken. Example:
+"Every story needs acceptance criteria before it reaches a sprint." -->
+
+## Glossary
+
+<!-- Terms with a specific meaning here. Example:
+"'Feature' means a customer-visible capability, not a Jira issue type." -->

--- a/core/memory/project.md
+++ b/core/memory/project.md
@@ -1,0 +1,16 @@
+# Project memory
+
+What someone joining this project should know on day one. Agents cite this
+when drafting, so keep it current and honest.
+
+## What we're building and why
+
+## Key decisions so far
+
+<!-- Date, decision, why. New entries go on top. -->
+
+## Constraints that shape requirements
+
+<!-- Regulatory, technical, contractual, timeline. -->
+
+## Out of scope (and why)

--- a/core/memory/team.md
+++ b/core/memory/team.md
@@ -1,0 +1,16 @@
+# Team memory
+
+How this team likes to work. The estimation and review flows read this.
+
+## Working agreements
+
+<!-- Example: "Batch questions — don't ping us one at a time." -->
+
+## Estimation culture
+
+<!-- Which scale, what a '5' feels like, who confirms. Example:
+"Fibonacci points; a 5 is roughly a week for one person; leads confirm." -->
+
+## Review preferences
+
+<!-- Example: "Warnings are fine to ship with; blockers never are." -->

--- a/core/stages/bodies/apply-and-verify.md
+++ b/core/stages/bodies/apply-and-verify.md
@@ -1,0 +1,9 @@
+# Making it real, provably
+
+**Why this stage exists.** Each tracker write is verified by reading it back; every operation leaves a receipt. Interruptions resume without duplicates.
+
+**What you'll be asked.** Usually nothing; interruptions come with a clear recovery choice.
+
+**What you get.** Tracker items plus a receipt for every operation.
+
+**Done when.** Every planned operation is verified or explained.

--- a/core/stages/bodies/baseline.md
+++ b/core/stages/bodies/baseline.md
@@ -1,0 +1,9 @@
+# Freezing the agreed picture
+
+**Why this stage exists.** A baseline is the versioned snapshot everyone can point at later — 'this is what we agreed.' Changes after this go through change control, visibly.
+
+**What you'll be asked.** Confirmation that this is the moment to freeze.
+
+**What you get.** An immutable, verifiable baseline.
+
+**Done when.** The baseline exists and reproduces its verification hashes.

--- a/core/stages/bodies/changeset-planning.md
+++ b/core/stages/bodies/changeset-planning.md
@@ -1,0 +1,9 @@
+# Preview before the tracker changes
+
+**Why this stage exists.** Nothing writes to Jira or Boards silently. You see the exact items, fields, and links that would change, and nothing happens without your go-ahead.
+
+**What you'll be asked.** Review the preview; approve or hold the batch.
+
+**What you get.** A previewed changeset with each planned operation.
+
+**Done when.** You've read the preview and made the call.

--- a/core/stages/bodies/comment-resolution.md
+++ b/core/stages/bodies/comment-resolution.md
@@ -1,0 +1,9 @@
+# Closing the loop on feedback
+
+**Why this stage exists.** Tracker comments and stakeholder notes become decisions, changes, or answered questions — never silently lost.
+
+**What you'll be asked.** Your call on each open comment: incorporate, respond, or note why not.
+
+**What you get.** A disposition record linked to each exact comment.
+
+**Done when.** No material comment is left hanging.

--- a/core/stages/bodies/intent-framing.md
+++ b/core/stages/bodies/intent-framing.md
@@ -1,0 +1,9 @@
+# Saying what this is about
+
+**Why this stage exists.** Everything downstream traces back to the problem and outcomes written here. Ten minutes now saves rework later.
+
+**What you'll be asked.** A few questions about the problem, who it affects, and what success looks like.
+
+**What you get.** A short intent statement: problem, outcomes, success measures.
+
+**Done when.** You'd show the intent statement to a stakeholder without caveats.

--- a/core/stages/bodies/promotion-collision-review.md
+++ b/core/stages/bodies/promotion-collision-review.md
@@ -1,0 +1,9 @@
+# Merging parallel work
+
+**Why this stage exists.** When several people draft against the same requirements, this is where overlaps surface — before they become duplicate stories in the tracker.
+
+**What you'll be asked.** Your calls on overlaps: split, merge, keep both with a reason, or escalate.
+
+**What you get.** A recorded decision for every collision.
+
+**Done when.** No unexplained overlap remains.

--- a/core/stages/bodies/readiness-approval.md
+++ b/core/stages/bodies/readiness-approval.md
@@ -1,0 +1,9 @@
+# The sign-off
+
+**Why this stage exists.** Approvers see one immutable package — exactly what they're approving, with its evidence. Approval binds to that exact content; if it changes later, the approval visibly no longer covers it.
+
+**What you'll be asked.** Confirm the package contents; approvers record decisions through their verified identity.
+
+**What you get.** An approval package and the recorded decisions.
+
+**Done when.** The required approvers have approved this exact package.

--- a/core/stages/bodies/requirement-drafting.md
+++ b/core/stages/bodies/requirement-drafting.md
@@ -1,0 +1,9 @@
+# Writing the requirements
+
+**Why this stage exists.** Each requirement gets its full shape — who it's for, what must happen, how you'll know it's met — validated against your templates as it's written.
+
+**What you'll be asked.** Clarifications where sources are silent; you correct drafts as they appear.
+
+**What you get.** Traceable requirements, each linked to its evidence.
+
+**Done when.** Each requirement reads true, complete, and testable to you.

--- a/core/stages/bodies/schema-template-validation.md
+++ b/core/stages/bodies/schema-template-validation.md
@@ -1,0 +1,9 @@
+# Completeness check
+
+**Why this stage exists.** A mechanical pass over every item: expected sections present, links intact, nothing malformed. No judgment calls — just facts.
+
+**What you'll be asked.** Nothing; results come to you.
+
+**What you get.** A plain list: what's complete, what's missing what.
+
+**Done when.** No item is missing required content, or the gaps are consciously accepted.

--- a/core/stages/bodies/scope-selection.md
+++ b/core/stages/bodies/scope-selection.md
@@ -1,0 +1,9 @@
+# Choosing how much ceremony
+
+**Why this stage exists.** Different work needs different depth. A quick fix shouldn't fill in portfolio paperwork; a regulated release shouldn't skip evidence.
+
+**What you'll be asked.** One question: which of the seven scopes fits — with a recommendation and what each includes.
+
+**What you get.** An execution plan listing exactly which stages will run.
+
+**Done when.** You've confirmed the scope and seen which stages it includes and trims.

--- a/core/stages/bodies/semantic-review.md
+++ b/core/stages/bodies/semantic-review.md
@@ -1,0 +1,9 @@
+# Quality suggestions
+
+**Why this stage exists.** A second pair of eyes for wording: vague terms, two-requirements-in-one, unmeasurable expectations. These are suggestions — you decide.
+
+**What you'll be asked.** Accept, adjust, or dismiss each suggestion.
+
+**What you get.** A dispositioned suggestion list.
+
+**Done when.** Every suggestion has your decision on it.

--- a/core/stages/bodies/source-discovery.md
+++ b/core/stages/bodies/source-discovery.md
@@ -1,0 +1,9 @@
+# Gathering the evidence
+
+**Why this stage exists.** Requirements grounded in real documents and tracker history survive scrutiny; folklore doesn't.
+
+**What you'll be asked.** Point at documents, wiki exports, or tracker projects worth reading.
+
+**What you get.** Snapshots of every source with exactly what was and wasn't readable.
+
+**Done when.** The evidence list covers what you'd want to cite in a review.

--- a/core/stages/bodies/stakeholder-governance-mapping.md
+++ b/core/stages/bodies/stakeholder-governance-mapping.md
@@ -1,0 +1,9 @@
+# Who's involved, who approves
+
+**Why this stage exists.** Everyone affected gets recorded; the *approvers* are the deliberate, smaller list — that difference prevents both bottlenecks and surprises.
+
+**What you'll be asked.** Who is affected, who reviews, who must approve, in what order.
+
+**What you get.** A stakeholder registry and the approval roles for this engagement.
+
+**Done when.** The people who must say yes are named and they know it.

--- a/core/stages/bodies/trace-coverage-review.md
+++ b/core/stages/bodies/trace-coverage-review.md
@@ -1,0 +1,9 @@
+# Does everything connect?
+
+**Why this stage exists.** Orphans are risk: a requirement no story covers, a story no requirement justifies, criteria no test will check.
+
+**What you'll be asked.** Nothing; gaps come to you with owners suggested.
+
+**What you get.** A coverage map at requirement and criterion level.
+
+**Done when.** Every gap is either closed or assigned.

--- a/core/stages/bodies/workspace-detection.md
+++ b/core/stages/bodies/workspace-detection.md
@@ -1,0 +1,9 @@
+# Getting oriented
+
+**Why this stage exists.** R-DLC looks at what's already here — project settings, tracker connections, any earlier engagement — so it never asks you things it can find out itself.
+
+**What you'll be asked.** Nothing; this runs by itself.
+
+**What you get.** A short readout of what was found and what's missing.
+
+**Done when.** You've seen the readout and nothing important is missing.

--- a/distribution/claude-code/hooks/guard.mjs
+++ b/distribution/claude-code/hooks/guard.mjs
@@ -12,6 +12,9 @@ process.stdin.on("data", (chunk) => { input += chunk; });
 process.stdin.on("end", () => {
   let path = "";
   try { path = JSON.parse(input)?.tool_input?.file_path ?? ""; } catch { /* no path, allow */ }
+  // Normalize before matching: backslashes, duplicate slashes, and ./ hops
+  // must not slip past the rules (defense in depth).
+  path = String(path).replace(/\\/g, "/").replace(/\/\.\//g, "/").replace(/\/{2,}/g, "/");
   const rules = [
     [/rdlc\/(spaces\/[^/]+\/engagements\/[^/]+\/)?(approvals|baselines)\//,
       "Approvals and baselines are evidence — editing them by hand would break the audit trail. Use /rdlc-approve or /rdlc-baseline instead."],

--- a/distribution/claude-code/hooks/guard.mjs
+++ b/distribution/claude-code/hooks/guard.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * R-DLC write guard (PreToolUse hook for Write|Edit). Dependency-free.
+ *
+ * Approvals, baselines, and the reference library only change through their
+ * governed commands — a direct file edit would break the evidence chain.
+ * The message explains that in plain language; exit 2 blocks the edit.
+ */
+
+let input = "";
+process.stdin.on("data", (chunk) => { input += chunk; });
+process.stdin.on("end", () => {
+  let path = "";
+  try { path = JSON.parse(input)?.tool_input?.file_path ?? ""; } catch { /* no path, allow */ }
+  const rules = [
+    [/rdlc\/(spaces\/[^/]+\/engagements\/[^/]+\/)?(approvals|baselines)\//,
+      "Approvals and baselines are evidence — editing them by hand would break the audit trail. Use /rdlc-approve or /rdlc-baseline instead."],
+    [/rdlc\/reference\//,
+      "The rdlc/reference files are the shared playbook installed by R-DLC. To change how the workflow behaves, change project policy or rerun setup — direct edits here get overwritten on upgrade."],
+    [/rdlc\/\.install-manifest\.json$/,
+      "This file is R-DLC's record of what it installed. It maintains itself."]
+  ];
+  for (const [pattern, message] of rules) {
+    if (pattern.test(path)) {
+      console.error(message);
+      process.exit(2);
+    }
+  }
+  process.exit(0);
+});

--- a/distribution/claude-code/hooks/hooks.json
+++ b/distribution/claude-code/hooks/hooks.json
@@ -1,0 +1,25 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node rdlc/hooks/orient.mjs"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node rdlc/hooks/guard.mjs"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/distribution/claude-code/hooks/orient.mjs
+++ b/distribution/claude-code/hooks/orient.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * R-DLC session orientation (SessionStart hook). Dependency-free: prints one
+ * friendly line about where the engagement stands so a returning BA/PO knows
+ * exactly where they left off. Never blocks the session.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+function scalar(text, key) {
+  const match = text.match(new RegExp(`^${key}:\\s*(.+)$`, "m"));
+  return match ? match[1].trim().replace(/^["']|["']$/g, "") : null;
+}
+
+try {
+  const base = join(process.cwd(), "rdlc", "spaces");
+  const found = [];
+  for (const space of readdirSync(base)) {
+    const engagements = join(base, space, "engagements");
+    let ids = [];
+    try { ids = readdirSync(engagements); } catch { continue; }
+    for (const id of ids) {
+      try {
+        const text = readFileSync(join(engagements, id, "rdlc-state.yaml"), "utf8");
+        found.push({
+          scope: scalar(text, "scope"),
+          stage: scalar(text, "active_stage"),
+          next: scalar(text, "next_action"),
+          updated: scalar(text, "updated_at")
+        });
+      } catch { /* unreadable state surfaces via /rdlc-status */ }
+    }
+  }
+  if (found.length === 0) {
+    console.log("R-DLC is set up here but no engagement has started — /rdlc-start begins one.");
+  } else {
+    const latest = found.sort((a, b) => String(b.updated).localeCompare(String(a.updated)))[0];
+    console.log(`R-DLC: ${found.length > 1 ? `${found.length} engagements; latest` : "engagement"} at stage "${latest.stage}" (${latest.scope} scope). Next: ${latest.next ?? "/rdlc-status"}`);
+  }
+} catch {
+  // No rdlc/ here — stay silent; this project may not use R-DLC.
+}
+process.exit(0);

--- a/distribution/claude-code/hooks/orient.mjs
+++ b/distribution/claude-code/hooks/orient.mjs
@@ -36,7 +36,12 @@ try {
     console.log("R-DLC is set up here but no engagement has started — /rdlc-start begins one.");
   } else {
     const latest = found.sort((a, b) => String(b.updated).localeCompare(String(a.updated)))[0];
-    console.log(`R-DLC: ${found.length > 1 ? `${found.length} engagements; latest` : "engagement"} at stage "${latest.stage}" (${latest.scope} scope). Next: ${latest.next ?? "/rdlc-status"}`);
+    const clean = (value) => value && /^[\w./ :-]{1,80}$/.test(value) ? value : null;
+    if (clean(latest.stage) && clean(latest.scope)) {
+      console.log(`R-DLC: ${found.length > 1 ? `${found.length} engagements; latest` : "engagement"} at stage "${clean(latest.stage)}" (${clean(latest.scope)} scope). Next: ${clean(latest.next) ?? "/rdlc-status"}`);
+    } else {
+      console.log("R-DLC: an engagement exists here — /rdlc-status has the details.");
+    }
   }
 } catch {
   // No rdlc/ here — stay silent; this project may not use R-DLC.

--- a/distribution/claude-code/reference/memory-templates/organization.md
+++ b/distribution/claude-code/reference/memory-templates/organization.md
@@ -1,0 +1,19 @@
+# Organization memory
+
+R-DLC reads this at the start of every session so agents follow your
+organization's rules without being reminded.
+
+## Approval culture
+
+<!-- Who must approve what, in your words. Example:
+"Compliance signs off on anything touching customer data. Product owns scope." -->
+
+## Locked policies
+
+<!-- Rules no project may weaken. Example:
+"Every story needs acceptance criteria before it reaches a sprint." -->
+
+## Glossary
+
+<!-- Terms with a specific meaning here. Example:
+"'Feature' means a customer-visible capability, not a Jira issue type." -->

--- a/distribution/claude-code/reference/memory-templates/project.md
+++ b/distribution/claude-code/reference/memory-templates/project.md
@@ -1,0 +1,16 @@
+# Project memory
+
+What someone joining this project should know on day one. Agents cite this
+when drafting, so keep it current and honest.
+
+## What we're building and why
+
+## Key decisions so far
+
+<!-- Date, decision, why. New entries go on top. -->
+
+## Constraints that shape requirements
+
+<!-- Regulatory, technical, contractual, timeline. -->
+
+## Out of scope (and why)

--- a/distribution/claude-code/reference/memory-templates/team.md
+++ b/distribution/claude-code/reference/memory-templates/team.md
@@ -1,0 +1,16 @@
+# Team memory
+
+How this team likes to work. The estimation and review flows read this.
+
+## Working agreements
+
+<!-- Example: "Batch questions — don't ping us one at a time." -->
+
+## Estimation culture
+
+<!-- Which scale, what a '5' feels like, who confirms. Example:
+"Fibonacci points; a 5 is roughly a week for one person; leads confirm." -->
+
+## Review preferences
+
+<!-- Example: "Warnings are fine to ship with; blockers never are." -->

--- a/distribution/claude-code/reference/stages/apply-and-verify.md
+++ b/distribution/claude-code/reference/stages/apply-and-verify.md
@@ -1,0 +1,9 @@
+# Making it real, provably
+
+**Why this stage exists.** Each tracker write is verified by reading it back; every operation leaves a receipt. Interruptions resume without duplicates.
+
+**What you'll be asked.** Usually nothing; interruptions come with a clear recovery choice.
+
+**What you get.** Tracker items plus a receipt for every operation.
+
+**Done when.** Every planned operation is verified or explained.

--- a/distribution/claude-code/reference/stages/baseline.md
+++ b/distribution/claude-code/reference/stages/baseline.md
@@ -1,0 +1,9 @@
+# Freezing the agreed picture
+
+**Why this stage exists.** A baseline is the versioned snapshot everyone can point at later — 'this is what we agreed.' Changes after this go through change control, visibly.
+
+**What you'll be asked.** Confirmation that this is the moment to freeze.
+
+**What you get.** An immutable, verifiable baseline.
+
+**Done when.** The baseline exists and reproduces its verification hashes.

--- a/distribution/claude-code/reference/stages/changeset-planning.md
+++ b/distribution/claude-code/reference/stages/changeset-planning.md
@@ -1,0 +1,9 @@
+# Preview before the tracker changes
+
+**Why this stage exists.** Nothing writes to Jira or Boards silently. You see the exact items, fields, and links that would change, and nothing happens without your go-ahead.
+
+**What you'll be asked.** Review the preview; approve or hold the batch.
+
+**What you get.** A previewed changeset with each planned operation.
+
+**Done when.** You've read the preview and made the call.

--- a/distribution/claude-code/reference/stages/comment-resolution.md
+++ b/distribution/claude-code/reference/stages/comment-resolution.md
@@ -1,0 +1,9 @@
+# Closing the loop on feedback
+
+**Why this stage exists.** Tracker comments and stakeholder notes become decisions, changes, or answered questions — never silently lost.
+
+**What you'll be asked.** Your call on each open comment: incorporate, respond, or note why not.
+
+**What you get.** A disposition record linked to each exact comment.
+
+**Done when.** No material comment is left hanging.

--- a/distribution/claude-code/reference/stages/intent-framing.md
+++ b/distribution/claude-code/reference/stages/intent-framing.md
@@ -1,0 +1,9 @@
+# Saying what this is about
+
+**Why this stage exists.** Everything downstream traces back to the problem and outcomes written here. Ten minutes now saves rework later.
+
+**What you'll be asked.** A few questions about the problem, who it affects, and what success looks like.
+
+**What you get.** A short intent statement: problem, outcomes, success measures.
+
+**Done when.** You'd show the intent statement to a stakeholder without caveats.

--- a/distribution/claude-code/reference/stages/promotion-collision-review.md
+++ b/distribution/claude-code/reference/stages/promotion-collision-review.md
@@ -1,0 +1,9 @@
+# Merging parallel work
+
+**Why this stage exists.** When several people draft against the same requirements, this is where overlaps surface — before they become duplicate stories in the tracker.
+
+**What you'll be asked.** Your calls on overlaps: split, merge, keep both with a reason, or escalate.
+
+**What you get.** A recorded decision for every collision.
+
+**Done when.** No unexplained overlap remains.

--- a/distribution/claude-code/reference/stages/readiness-approval.md
+++ b/distribution/claude-code/reference/stages/readiness-approval.md
@@ -1,0 +1,9 @@
+# The sign-off
+
+**Why this stage exists.** Approvers see one immutable package — exactly what they're approving, with its evidence. Approval binds to that exact content; if it changes later, the approval visibly no longer covers it.
+
+**What you'll be asked.** Confirm the package contents; approvers record decisions through their verified identity.
+
+**What you get.** An approval package and the recorded decisions.
+
+**Done when.** The required approvers have approved this exact package.

--- a/distribution/claude-code/reference/stages/requirement-drafting.md
+++ b/distribution/claude-code/reference/stages/requirement-drafting.md
@@ -1,0 +1,9 @@
+# Writing the requirements
+
+**Why this stage exists.** Each requirement gets its full shape — who it's for, what must happen, how you'll know it's met — validated against your templates as it's written.
+
+**What you'll be asked.** Clarifications where sources are silent; you correct drafts as they appear.
+
+**What you get.** Traceable requirements, each linked to its evidence.
+
+**Done when.** Each requirement reads true, complete, and testable to you.

--- a/distribution/claude-code/reference/stages/schema-template-validation.md
+++ b/distribution/claude-code/reference/stages/schema-template-validation.md
@@ -1,0 +1,9 @@
+# Completeness check
+
+**Why this stage exists.** A mechanical pass over every item: expected sections present, links intact, nothing malformed. No judgment calls — just facts.
+
+**What you'll be asked.** Nothing; results come to you.
+
+**What you get.** A plain list: what's complete, what's missing what.
+
+**Done when.** No item is missing required content, or the gaps are consciously accepted.

--- a/distribution/claude-code/reference/stages/scope-selection.md
+++ b/distribution/claude-code/reference/stages/scope-selection.md
@@ -1,0 +1,9 @@
+# Choosing how much ceremony
+
+**Why this stage exists.** Different work needs different depth. A quick fix shouldn't fill in portfolio paperwork; a regulated release shouldn't skip evidence.
+
+**What you'll be asked.** One question: which of the seven scopes fits — with a recommendation and what each includes.
+
+**What you get.** An execution plan listing exactly which stages will run.
+
+**Done when.** You've confirmed the scope and seen which stages it includes and trims.

--- a/distribution/claude-code/reference/stages/semantic-review.md
+++ b/distribution/claude-code/reference/stages/semantic-review.md
@@ -1,0 +1,9 @@
+# Quality suggestions
+
+**Why this stage exists.** A second pair of eyes for wording: vague terms, two-requirements-in-one, unmeasurable expectations. These are suggestions — you decide.
+
+**What you'll be asked.** Accept, adjust, or dismiss each suggestion.
+
+**What you get.** A dispositioned suggestion list.
+
+**Done when.** Every suggestion has your decision on it.

--- a/distribution/claude-code/reference/stages/source-discovery.md
+++ b/distribution/claude-code/reference/stages/source-discovery.md
@@ -1,0 +1,9 @@
+# Gathering the evidence
+
+**Why this stage exists.** Requirements grounded in real documents and tracker history survive scrutiny; folklore doesn't.
+
+**What you'll be asked.** Point at documents, wiki exports, or tracker projects worth reading.
+
+**What you get.** Snapshots of every source with exactly what was and wasn't readable.
+
+**Done when.** The evidence list covers what you'd want to cite in a review.

--- a/distribution/claude-code/reference/stages/stakeholder-governance-mapping.md
+++ b/distribution/claude-code/reference/stages/stakeholder-governance-mapping.md
@@ -1,0 +1,9 @@
+# Who's involved, who approves
+
+**Why this stage exists.** Everyone affected gets recorded; the *approvers* are the deliberate, smaller list — that difference prevents both bottlenecks and surprises.
+
+**What you'll be asked.** Who is affected, who reviews, who must approve, in what order.
+
+**What you get.** A stakeholder registry and the approval roles for this engagement.
+
+**Done when.** The people who must say yes are named and they know it.

--- a/distribution/claude-code/reference/stages/trace-coverage-review.md
+++ b/distribution/claude-code/reference/stages/trace-coverage-review.md
@@ -1,0 +1,9 @@
+# Does everything connect?
+
+**Why this stage exists.** Orphans are risk: a requirement no story covers, a story no requirement justifies, criteria no test will check.
+
+**What you'll be asked.** Nothing; gaps come to you with owners suggested.
+
+**What you get.** A coverage map at requirement and criterion level.
+
+**Done when.** Every gap is either closed or assigned.

--- a/distribution/claude-code/reference/stages/workspace-detection.md
+++ b/distribution/claude-code/reference/stages/workspace-detection.md
@@ -1,0 +1,9 @@
+# Getting oriented
+
+**Why this stage exists.** R-DLC looks at what's already here — project settings, tracker connections, any earlier engagement — so it never asks you things it can find out itself.
+
+**What you'll be asked.** Nothing; this runs by itself.
+
+**What you get.** A short readout of what was found and what's missing.
+
+**Done when.** You've seen the readout and nothing important is missing.

--- a/distribution/codex/reference/memory-templates/organization.md
+++ b/distribution/codex/reference/memory-templates/organization.md
@@ -1,0 +1,19 @@
+# Organization memory
+
+R-DLC reads this at the start of every session so agents follow your
+organization's rules without being reminded.
+
+## Approval culture
+
+<!-- Who must approve what, in your words. Example:
+"Compliance signs off on anything touching customer data. Product owns scope." -->
+
+## Locked policies
+
+<!-- Rules no project may weaken. Example:
+"Every story needs acceptance criteria before it reaches a sprint." -->
+
+## Glossary
+
+<!-- Terms with a specific meaning here. Example:
+"'Feature' means a customer-visible capability, not a Jira issue type." -->

--- a/distribution/codex/reference/memory-templates/project.md
+++ b/distribution/codex/reference/memory-templates/project.md
@@ -1,0 +1,16 @@
+# Project memory
+
+What someone joining this project should know on day one. Agents cite this
+when drafting, so keep it current and honest.
+
+## What we're building and why
+
+## Key decisions so far
+
+<!-- Date, decision, why. New entries go on top. -->
+
+## Constraints that shape requirements
+
+<!-- Regulatory, technical, contractual, timeline. -->
+
+## Out of scope (and why)

--- a/distribution/codex/reference/memory-templates/team.md
+++ b/distribution/codex/reference/memory-templates/team.md
@@ -1,0 +1,16 @@
+# Team memory
+
+How this team likes to work. The estimation and review flows read this.
+
+## Working agreements
+
+<!-- Example: "Batch questions — don't ping us one at a time." -->
+
+## Estimation culture
+
+<!-- Which scale, what a '5' feels like, who confirms. Example:
+"Fibonacci points; a 5 is roughly a week for one person; leads confirm." -->
+
+## Review preferences
+
+<!-- Example: "Warnings are fine to ship with; blockers never are." -->

--- a/distribution/codex/reference/stages/apply-and-verify.md
+++ b/distribution/codex/reference/stages/apply-and-verify.md
@@ -1,0 +1,9 @@
+# Making it real, provably
+
+**Why this stage exists.** Each tracker write is verified by reading it back; every operation leaves a receipt. Interruptions resume without duplicates.
+
+**What you'll be asked.** Usually nothing; interruptions come with a clear recovery choice.
+
+**What you get.** Tracker items plus a receipt for every operation.
+
+**Done when.** Every planned operation is verified or explained.

--- a/distribution/codex/reference/stages/baseline.md
+++ b/distribution/codex/reference/stages/baseline.md
@@ -1,0 +1,9 @@
+# Freezing the agreed picture
+
+**Why this stage exists.** A baseline is the versioned snapshot everyone can point at later — 'this is what we agreed.' Changes after this go through change control, visibly.
+
+**What you'll be asked.** Confirmation that this is the moment to freeze.
+
+**What you get.** An immutable, verifiable baseline.
+
+**Done when.** The baseline exists and reproduces its verification hashes.

--- a/distribution/codex/reference/stages/changeset-planning.md
+++ b/distribution/codex/reference/stages/changeset-planning.md
@@ -1,0 +1,9 @@
+# Preview before the tracker changes
+
+**Why this stage exists.** Nothing writes to Jira or Boards silently. You see the exact items, fields, and links that would change, and nothing happens without your go-ahead.
+
+**What you'll be asked.** Review the preview; approve or hold the batch.
+
+**What you get.** A previewed changeset with each planned operation.
+
+**Done when.** You've read the preview and made the call.

--- a/distribution/codex/reference/stages/comment-resolution.md
+++ b/distribution/codex/reference/stages/comment-resolution.md
@@ -1,0 +1,9 @@
+# Closing the loop on feedback
+
+**Why this stage exists.** Tracker comments and stakeholder notes become decisions, changes, or answered questions — never silently lost.
+
+**What you'll be asked.** Your call on each open comment: incorporate, respond, or note why not.
+
+**What you get.** A disposition record linked to each exact comment.
+
+**Done when.** No material comment is left hanging.

--- a/distribution/codex/reference/stages/intent-framing.md
+++ b/distribution/codex/reference/stages/intent-framing.md
@@ -1,0 +1,9 @@
+# Saying what this is about
+
+**Why this stage exists.** Everything downstream traces back to the problem and outcomes written here. Ten minutes now saves rework later.
+
+**What you'll be asked.** A few questions about the problem, who it affects, and what success looks like.
+
+**What you get.** A short intent statement: problem, outcomes, success measures.
+
+**Done when.** You'd show the intent statement to a stakeholder without caveats.

--- a/distribution/codex/reference/stages/promotion-collision-review.md
+++ b/distribution/codex/reference/stages/promotion-collision-review.md
@@ -1,0 +1,9 @@
+# Merging parallel work
+
+**Why this stage exists.** When several people draft against the same requirements, this is where overlaps surface — before they become duplicate stories in the tracker.
+
+**What you'll be asked.** Your calls on overlaps: split, merge, keep both with a reason, or escalate.
+
+**What you get.** A recorded decision for every collision.
+
+**Done when.** No unexplained overlap remains.

--- a/distribution/codex/reference/stages/readiness-approval.md
+++ b/distribution/codex/reference/stages/readiness-approval.md
@@ -1,0 +1,9 @@
+# The sign-off
+
+**Why this stage exists.** Approvers see one immutable package — exactly what they're approving, with its evidence. Approval binds to that exact content; if it changes later, the approval visibly no longer covers it.
+
+**What you'll be asked.** Confirm the package contents; approvers record decisions through their verified identity.
+
+**What you get.** An approval package and the recorded decisions.
+
+**Done when.** The required approvers have approved this exact package.

--- a/distribution/codex/reference/stages/requirement-drafting.md
+++ b/distribution/codex/reference/stages/requirement-drafting.md
@@ -1,0 +1,9 @@
+# Writing the requirements
+
+**Why this stage exists.** Each requirement gets its full shape — who it's for, what must happen, how you'll know it's met — validated against your templates as it's written.
+
+**What you'll be asked.** Clarifications where sources are silent; you correct drafts as they appear.
+
+**What you get.** Traceable requirements, each linked to its evidence.
+
+**Done when.** Each requirement reads true, complete, and testable to you.

--- a/distribution/codex/reference/stages/schema-template-validation.md
+++ b/distribution/codex/reference/stages/schema-template-validation.md
@@ -1,0 +1,9 @@
+# Completeness check
+
+**Why this stage exists.** A mechanical pass over every item: expected sections present, links intact, nothing malformed. No judgment calls — just facts.
+
+**What you'll be asked.** Nothing; results come to you.
+
+**What you get.** A plain list: what's complete, what's missing what.
+
+**Done when.** No item is missing required content, or the gaps are consciously accepted.

--- a/distribution/codex/reference/stages/scope-selection.md
+++ b/distribution/codex/reference/stages/scope-selection.md
@@ -1,0 +1,9 @@
+# Choosing how much ceremony
+
+**Why this stage exists.** Different work needs different depth. A quick fix shouldn't fill in portfolio paperwork; a regulated release shouldn't skip evidence.
+
+**What you'll be asked.** One question: which of the seven scopes fits — with a recommendation and what each includes.
+
+**What you get.** An execution plan listing exactly which stages will run.
+
+**Done when.** You've confirmed the scope and seen which stages it includes and trims.

--- a/distribution/codex/reference/stages/semantic-review.md
+++ b/distribution/codex/reference/stages/semantic-review.md
@@ -1,0 +1,9 @@
+# Quality suggestions
+
+**Why this stage exists.** A second pair of eyes for wording: vague terms, two-requirements-in-one, unmeasurable expectations. These are suggestions — you decide.
+
+**What you'll be asked.** Accept, adjust, or dismiss each suggestion.
+
+**What you get.** A dispositioned suggestion list.
+
+**Done when.** Every suggestion has your decision on it.

--- a/distribution/codex/reference/stages/source-discovery.md
+++ b/distribution/codex/reference/stages/source-discovery.md
@@ -1,0 +1,9 @@
+# Gathering the evidence
+
+**Why this stage exists.** Requirements grounded in real documents and tracker history survive scrutiny; folklore doesn't.
+
+**What you'll be asked.** Point at documents, wiki exports, or tracker projects worth reading.
+
+**What you get.** Snapshots of every source with exactly what was and wasn't readable.
+
+**Done when.** The evidence list covers what you'd want to cite in a review.

--- a/distribution/codex/reference/stages/stakeholder-governance-mapping.md
+++ b/distribution/codex/reference/stages/stakeholder-governance-mapping.md
@@ -1,0 +1,9 @@
+# Who's involved, who approves
+
+**Why this stage exists.** Everyone affected gets recorded; the *approvers* are the deliberate, smaller list — that difference prevents both bottlenecks and surprises.
+
+**What you'll be asked.** Who is affected, who reviews, who must approve, in what order.
+
+**What you get.** A stakeholder registry and the approval roles for this engagement.
+
+**Done when.** The people who must say yes are named and they know it.

--- a/distribution/codex/reference/stages/trace-coverage-review.md
+++ b/distribution/codex/reference/stages/trace-coverage-review.md
@@ -1,0 +1,9 @@
+# Does everything connect?
+
+**Why this stage exists.** Orphans are risk: a requirement no story covers, a story no requirement justifies, criteria no test will check.
+
+**What you'll be asked.** Nothing; gaps come to you with owners suggested.
+
+**What you get.** A coverage map at requirement and criterion level.
+
+**Done when.** Every gap is either closed or assigned.

--- a/distribution/codex/reference/stages/workspace-detection.md
+++ b/distribution/codex/reference/stages/workspace-detection.md
@@ -1,0 +1,9 @@
+# Getting oriented
+
+**Why this stage exists.** R-DLC looks at what's already here — project settings, tracker connections, any earlier engagement — so it never asks you things it can find out itself.
+
+**What you'll be asked.** Nothing; this runs by itself.
+
+**What you get.** A short readout of what was found and what's missing.
+
+**Done when.** You've seen the readout and nothing important is missing.

--- a/distribution/kiro-ide/reference/memory-templates/organization.md
+++ b/distribution/kiro-ide/reference/memory-templates/organization.md
@@ -1,0 +1,19 @@
+# Organization memory
+
+R-DLC reads this at the start of every session so agents follow your
+organization's rules without being reminded.
+
+## Approval culture
+
+<!-- Who must approve what, in your words. Example:
+"Compliance signs off on anything touching customer data. Product owns scope." -->
+
+## Locked policies
+
+<!-- Rules no project may weaken. Example:
+"Every story needs acceptance criteria before it reaches a sprint." -->
+
+## Glossary
+
+<!-- Terms with a specific meaning here. Example:
+"'Feature' means a customer-visible capability, not a Jira issue type." -->

--- a/distribution/kiro-ide/reference/memory-templates/project.md
+++ b/distribution/kiro-ide/reference/memory-templates/project.md
@@ -1,0 +1,16 @@
+# Project memory
+
+What someone joining this project should know on day one. Agents cite this
+when drafting, so keep it current and honest.
+
+## What we're building and why
+
+## Key decisions so far
+
+<!-- Date, decision, why. New entries go on top. -->
+
+## Constraints that shape requirements
+
+<!-- Regulatory, technical, contractual, timeline. -->
+
+## Out of scope (and why)

--- a/distribution/kiro-ide/reference/memory-templates/team.md
+++ b/distribution/kiro-ide/reference/memory-templates/team.md
@@ -1,0 +1,16 @@
+# Team memory
+
+How this team likes to work. The estimation and review flows read this.
+
+## Working agreements
+
+<!-- Example: "Batch questions — don't ping us one at a time." -->
+
+## Estimation culture
+
+<!-- Which scale, what a '5' feels like, who confirms. Example:
+"Fibonacci points; a 5 is roughly a week for one person; leads confirm." -->
+
+## Review preferences
+
+<!-- Example: "Warnings are fine to ship with; blockers never are." -->

--- a/distribution/kiro-ide/reference/stages/apply-and-verify.md
+++ b/distribution/kiro-ide/reference/stages/apply-and-verify.md
@@ -1,0 +1,9 @@
+# Making it real, provably
+
+**Why this stage exists.** Each tracker write is verified by reading it back; every operation leaves a receipt. Interruptions resume without duplicates.
+
+**What you'll be asked.** Usually nothing; interruptions come with a clear recovery choice.
+
+**What you get.** Tracker items plus a receipt for every operation.
+
+**Done when.** Every planned operation is verified or explained.

--- a/distribution/kiro-ide/reference/stages/baseline.md
+++ b/distribution/kiro-ide/reference/stages/baseline.md
@@ -1,0 +1,9 @@
+# Freezing the agreed picture
+
+**Why this stage exists.** A baseline is the versioned snapshot everyone can point at later — 'this is what we agreed.' Changes after this go through change control, visibly.
+
+**What you'll be asked.** Confirmation that this is the moment to freeze.
+
+**What you get.** An immutable, verifiable baseline.
+
+**Done when.** The baseline exists and reproduces its verification hashes.

--- a/distribution/kiro-ide/reference/stages/changeset-planning.md
+++ b/distribution/kiro-ide/reference/stages/changeset-planning.md
@@ -1,0 +1,9 @@
+# Preview before the tracker changes
+
+**Why this stage exists.** Nothing writes to Jira or Boards silently. You see the exact items, fields, and links that would change, and nothing happens without your go-ahead.
+
+**What you'll be asked.** Review the preview; approve or hold the batch.
+
+**What you get.** A previewed changeset with each planned operation.
+
+**Done when.** You've read the preview and made the call.

--- a/distribution/kiro-ide/reference/stages/comment-resolution.md
+++ b/distribution/kiro-ide/reference/stages/comment-resolution.md
@@ -1,0 +1,9 @@
+# Closing the loop on feedback
+
+**Why this stage exists.** Tracker comments and stakeholder notes become decisions, changes, or answered questions — never silently lost.
+
+**What you'll be asked.** Your call on each open comment: incorporate, respond, or note why not.
+
+**What you get.** A disposition record linked to each exact comment.
+
+**Done when.** No material comment is left hanging.

--- a/distribution/kiro-ide/reference/stages/intent-framing.md
+++ b/distribution/kiro-ide/reference/stages/intent-framing.md
@@ -1,0 +1,9 @@
+# Saying what this is about
+
+**Why this stage exists.** Everything downstream traces back to the problem and outcomes written here. Ten minutes now saves rework later.
+
+**What you'll be asked.** A few questions about the problem, who it affects, and what success looks like.
+
+**What you get.** A short intent statement: problem, outcomes, success measures.
+
+**Done when.** You'd show the intent statement to a stakeholder without caveats.

--- a/distribution/kiro-ide/reference/stages/promotion-collision-review.md
+++ b/distribution/kiro-ide/reference/stages/promotion-collision-review.md
@@ -1,0 +1,9 @@
+# Merging parallel work
+
+**Why this stage exists.** When several people draft against the same requirements, this is where overlaps surface — before they become duplicate stories in the tracker.
+
+**What you'll be asked.** Your calls on overlaps: split, merge, keep both with a reason, or escalate.
+
+**What you get.** A recorded decision for every collision.
+
+**Done when.** No unexplained overlap remains.

--- a/distribution/kiro-ide/reference/stages/readiness-approval.md
+++ b/distribution/kiro-ide/reference/stages/readiness-approval.md
@@ -1,0 +1,9 @@
+# The sign-off
+
+**Why this stage exists.** Approvers see one immutable package — exactly what they're approving, with its evidence. Approval binds to that exact content; if it changes later, the approval visibly no longer covers it.
+
+**What you'll be asked.** Confirm the package contents; approvers record decisions through their verified identity.
+
+**What you get.** An approval package and the recorded decisions.
+
+**Done when.** The required approvers have approved this exact package.

--- a/distribution/kiro-ide/reference/stages/requirement-drafting.md
+++ b/distribution/kiro-ide/reference/stages/requirement-drafting.md
@@ -1,0 +1,9 @@
+# Writing the requirements
+
+**Why this stage exists.** Each requirement gets its full shape — who it's for, what must happen, how you'll know it's met — validated against your templates as it's written.
+
+**What you'll be asked.** Clarifications where sources are silent; you correct drafts as they appear.
+
+**What you get.** Traceable requirements, each linked to its evidence.
+
+**Done when.** Each requirement reads true, complete, and testable to you.

--- a/distribution/kiro-ide/reference/stages/schema-template-validation.md
+++ b/distribution/kiro-ide/reference/stages/schema-template-validation.md
@@ -1,0 +1,9 @@
+# Completeness check
+
+**Why this stage exists.** A mechanical pass over every item: expected sections present, links intact, nothing malformed. No judgment calls — just facts.
+
+**What you'll be asked.** Nothing; results come to you.
+
+**What you get.** A plain list: what's complete, what's missing what.
+
+**Done when.** No item is missing required content, or the gaps are consciously accepted.

--- a/distribution/kiro-ide/reference/stages/scope-selection.md
+++ b/distribution/kiro-ide/reference/stages/scope-selection.md
@@ -1,0 +1,9 @@
+# Choosing how much ceremony
+
+**Why this stage exists.** Different work needs different depth. A quick fix shouldn't fill in portfolio paperwork; a regulated release shouldn't skip evidence.
+
+**What you'll be asked.** One question: which of the seven scopes fits — with a recommendation and what each includes.
+
+**What you get.** An execution plan listing exactly which stages will run.
+
+**Done when.** You've confirmed the scope and seen which stages it includes and trims.

--- a/distribution/kiro-ide/reference/stages/semantic-review.md
+++ b/distribution/kiro-ide/reference/stages/semantic-review.md
@@ -1,0 +1,9 @@
+# Quality suggestions
+
+**Why this stage exists.** A second pair of eyes for wording: vague terms, two-requirements-in-one, unmeasurable expectations. These are suggestions — you decide.
+
+**What you'll be asked.** Accept, adjust, or dismiss each suggestion.
+
+**What you get.** A dispositioned suggestion list.
+
+**Done when.** Every suggestion has your decision on it.

--- a/distribution/kiro-ide/reference/stages/source-discovery.md
+++ b/distribution/kiro-ide/reference/stages/source-discovery.md
@@ -1,0 +1,9 @@
+# Gathering the evidence
+
+**Why this stage exists.** Requirements grounded in real documents and tracker history survive scrutiny; folklore doesn't.
+
+**What you'll be asked.** Point at documents, wiki exports, or tracker projects worth reading.
+
+**What you get.** Snapshots of every source with exactly what was and wasn't readable.
+
+**Done when.** The evidence list covers what you'd want to cite in a review.

--- a/distribution/kiro-ide/reference/stages/stakeholder-governance-mapping.md
+++ b/distribution/kiro-ide/reference/stages/stakeholder-governance-mapping.md
@@ -1,0 +1,9 @@
+# Who's involved, who approves
+
+**Why this stage exists.** Everyone affected gets recorded; the *approvers* are the deliberate, smaller list — that difference prevents both bottlenecks and surprises.
+
+**What you'll be asked.** Who is affected, who reviews, who must approve, in what order.
+
+**What you get.** A stakeholder registry and the approval roles for this engagement.
+
+**Done when.** The people who must say yes are named and they know it.

--- a/distribution/kiro-ide/reference/stages/trace-coverage-review.md
+++ b/distribution/kiro-ide/reference/stages/trace-coverage-review.md
@@ -1,0 +1,9 @@
+# Does everything connect?
+
+**Why this stage exists.** Orphans are risk: a requirement no story covers, a story no requirement justifies, criteria no test will check.
+
+**What you'll be asked.** Nothing; gaps come to you with owners suggested.
+
+**What you get.** A coverage map at requirement and criterion level.
+
+**Done when.** Every gap is either closed or assigned.

--- a/distribution/kiro-ide/reference/stages/workspace-detection.md
+++ b/distribution/kiro-ide/reference/stages/workspace-detection.md
@@ -1,0 +1,9 @@
+# Getting oriented
+
+**Why this stage exists.** R-DLC looks at what's already here — project settings, tracker connections, any earlier engagement — so it never asks you things it can find out itself.
+
+**What you'll be asked.** Nothing; this runs by itself.
+
+**What you get.** A short readout of what was found and what's missing.
+
+**Done when.** You've seen the readout and nothing important is missing.

--- a/distribution/kiro/reference/memory-templates/organization.md
+++ b/distribution/kiro/reference/memory-templates/organization.md
@@ -1,0 +1,19 @@
+# Organization memory
+
+R-DLC reads this at the start of every session so agents follow your
+organization's rules without being reminded.
+
+## Approval culture
+
+<!-- Who must approve what, in your words. Example:
+"Compliance signs off on anything touching customer data. Product owns scope." -->
+
+## Locked policies
+
+<!-- Rules no project may weaken. Example:
+"Every story needs acceptance criteria before it reaches a sprint." -->
+
+## Glossary
+
+<!-- Terms with a specific meaning here. Example:
+"'Feature' means a customer-visible capability, not a Jira issue type." -->

--- a/distribution/kiro/reference/memory-templates/project.md
+++ b/distribution/kiro/reference/memory-templates/project.md
@@ -1,0 +1,16 @@
+# Project memory
+
+What someone joining this project should know on day one. Agents cite this
+when drafting, so keep it current and honest.
+
+## What we're building and why
+
+## Key decisions so far
+
+<!-- Date, decision, why. New entries go on top. -->
+
+## Constraints that shape requirements
+
+<!-- Regulatory, technical, contractual, timeline. -->
+
+## Out of scope (and why)

--- a/distribution/kiro/reference/memory-templates/team.md
+++ b/distribution/kiro/reference/memory-templates/team.md
@@ -1,0 +1,16 @@
+# Team memory
+
+How this team likes to work. The estimation and review flows read this.
+
+## Working agreements
+
+<!-- Example: "Batch questions — don't ping us one at a time." -->
+
+## Estimation culture
+
+<!-- Which scale, what a '5' feels like, who confirms. Example:
+"Fibonacci points; a 5 is roughly a week for one person; leads confirm." -->
+
+## Review preferences
+
+<!-- Example: "Warnings are fine to ship with; blockers never are." -->

--- a/distribution/kiro/reference/stages/apply-and-verify.md
+++ b/distribution/kiro/reference/stages/apply-and-verify.md
@@ -1,0 +1,9 @@
+# Making it real, provably
+
+**Why this stage exists.** Each tracker write is verified by reading it back; every operation leaves a receipt. Interruptions resume without duplicates.
+
+**What you'll be asked.** Usually nothing; interruptions come with a clear recovery choice.
+
+**What you get.** Tracker items plus a receipt for every operation.
+
+**Done when.** Every planned operation is verified or explained.

--- a/distribution/kiro/reference/stages/baseline.md
+++ b/distribution/kiro/reference/stages/baseline.md
@@ -1,0 +1,9 @@
+# Freezing the agreed picture
+
+**Why this stage exists.** A baseline is the versioned snapshot everyone can point at later — 'this is what we agreed.' Changes after this go through change control, visibly.
+
+**What you'll be asked.** Confirmation that this is the moment to freeze.
+
+**What you get.** An immutable, verifiable baseline.
+
+**Done when.** The baseline exists and reproduces its verification hashes.

--- a/distribution/kiro/reference/stages/changeset-planning.md
+++ b/distribution/kiro/reference/stages/changeset-planning.md
@@ -1,0 +1,9 @@
+# Preview before the tracker changes
+
+**Why this stage exists.** Nothing writes to Jira or Boards silently. You see the exact items, fields, and links that would change, and nothing happens without your go-ahead.
+
+**What you'll be asked.** Review the preview; approve or hold the batch.
+
+**What you get.** A previewed changeset with each planned operation.
+
+**Done when.** You've read the preview and made the call.

--- a/distribution/kiro/reference/stages/comment-resolution.md
+++ b/distribution/kiro/reference/stages/comment-resolution.md
@@ -1,0 +1,9 @@
+# Closing the loop on feedback
+
+**Why this stage exists.** Tracker comments and stakeholder notes become decisions, changes, or answered questions — never silently lost.
+
+**What you'll be asked.** Your call on each open comment: incorporate, respond, or note why not.
+
+**What you get.** A disposition record linked to each exact comment.
+
+**Done when.** No material comment is left hanging.

--- a/distribution/kiro/reference/stages/intent-framing.md
+++ b/distribution/kiro/reference/stages/intent-framing.md
@@ -1,0 +1,9 @@
+# Saying what this is about
+
+**Why this stage exists.** Everything downstream traces back to the problem and outcomes written here. Ten minutes now saves rework later.
+
+**What you'll be asked.** A few questions about the problem, who it affects, and what success looks like.
+
+**What you get.** A short intent statement: problem, outcomes, success measures.
+
+**Done when.** You'd show the intent statement to a stakeholder without caveats.

--- a/distribution/kiro/reference/stages/promotion-collision-review.md
+++ b/distribution/kiro/reference/stages/promotion-collision-review.md
@@ -1,0 +1,9 @@
+# Merging parallel work
+
+**Why this stage exists.** When several people draft against the same requirements, this is where overlaps surface — before they become duplicate stories in the tracker.
+
+**What you'll be asked.** Your calls on overlaps: split, merge, keep both with a reason, or escalate.
+
+**What you get.** A recorded decision for every collision.
+
+**Done when.** No unexplained overlap remains.

--- a/distribution/kiro/reference/stages/readiness-approval.md
+++ b/distribution/kiro/reference/stages/readiness-approval.md
@@ -1,0 +1,9 @@
+# The sign-off
+
+**Why this stage exists.** Approvers see one immutable package — exactly what they're approving, with its evidence. Approval binds to that exact content; if it changes later, the approval visibly no longer covers it.
+
+**What you'll be asked.** Confirm the package contents; approvers record decisions through their verified identity.
+
+**What you get.** An approval package and the recorded decisions.
+
+**Done when.** The required approvers have approved this exact package.

--- a/distribution/kiro/reference/stages/requirement-drafting.md
+++ b/distribution/kiro/reference/stages/requirement-drafting.md
@@ -1,0 +1,9 @@
+# Writing the requirements
+
+**Why this stage exists.** Each requirement gets its full shape — who it's for, what must happen, how you'll know it's met — validated against your templates as it's written.
+
+**What you'll be asked.** Clarifications where sources are silent; you correct drafts as they appear.
+
+**What you get.** Traceable requirements, each linked to its evidence.
+
+**Done when.** Each requirement reads true, complete, and testable to you.

--- a/distribution/kiro/reference/stages/schema-template-validation.md
+++ b/distribution/kiro/reference/stages/schema-template-validation.md
@@ -1,0 +1,9 @@
+# Completeness check
+
+**Why this stage exists.** A mechanical pass over every item: expected sections present, links intact, nothing malformed. No judgment calls — just facts.
+
+**What you'll be asked.** Nothing; results come to you.
+
+**What you get.** A plain list: what's complete, what's missing what.
+
+**Done when.** No item is missing required content, or the gaps are consciously accepted.

--- a/distribution/kiro/reference/stages/scope-selection.md
+++ b/distribution/kiro/reference/stages/scope-selection.md
@@ -1,0 +1,9 @@
+# Choosing how much ceremony
+
+**Why this stage exists.** Different work needs different depth. A quick fix shouldn't fill in portfolio paperwork; a regulated release shouldn't skip evidence.
+
+**What you'll be asked.** One question: which of the seven scopes fits — with a recommendation and what each includes.
+
+**What you get.** An execution plan listing exactly which stages will run.
+
+**Done when.** You've confirmed the scope and seen which stages it includes and trims.

--- a/distribution/kiro/reference/stages/semantic-review.md
+++ b/distribution/kiro/reference/stages/semantic-review.md
@@ -1,0 +1,9 @@
+# Quality suggestions
+
+**Why this stage exists.** A second pair of eyes for wording: vague terms, two-requirements-in-one, unmeasurable expectations. These are suggestions — you decide.
+
+**What you'll be asked.** Accept, adjust, or dismiss each suggestion.
+
+**What you get.** A dispositioned suggestion list.
+
+**Done when.** Every suggestion has your decision on it.

--- a/distribution/kiro/reference/stages/source-discovery.md
+++ b/distribution/kiro/reference/stages/source-discovery.md
@@ -1,0 +1,9 @@
+# Gathering the evidence
+
+**Why this stage exists.** Requirements grounded in real documents and tracker history survive scrutiny; folklore doesn't.
+
+**What you'll be asked.** Point at documents, wiki exports, or tracker projects worth reading.
+
+**What you get.** Snapshots of every source with exactly what was and wasn't readable.
+
+**Done when.** The evidence list covers what you'd want to cite in a review.

--- a/distribution/kiro/reference/stages/stakeholder-governance-mapping.md
+++ b/distribution/kiro/reference/stages/stakeholder-governance-mapping.md
@@ -1,0 +1,9 @@
+# Who's involved, who approves
+
+**Why this stage exists.** Everyone affected gets recorded; the *approvers* are the deliberate, smaller list — that difference prevents both bottlenecks and surprises.
+
+**What you'll be asked.** Who is affected, who reviews, who must approve, in what order.
+
+**What you get.** A stakeholder registry and the approval roles for this engagement.
+
+**Done when.** The people who must say yes are named and they know it.

--- a/distribution/kiro/reference/stages/trace-coverage-review.md
+++ b/distribution/kiro/reference/stages/trace-coverage-review.md
@@ -1,0 +1,9 @@
+# Does everything connect?
+
+**Why this stage exists.** Orphans are risk: a requirement no story covers, a story no requirement justifies, criteria no test will check.
+
+**What you'll be asked.** Nothing; gaps come to you with owners suggested.
+
+**What you get.** A coverage map at requirement and criterion level.
+
+**Done when.** Every gap is either closed or assigned.

--- a/distribution/kiro/reference/stages/workspace-detection.md
+++ b/distribution/kiro/reference/stages/workspace-detection.md
@@ -1,0 +1,9 @@
+# Getting oriented
+
+**Why this stage exists.** R-DLC looks at what's already here — project settings, tracker connections, any earlier engagement — so it never asks you things it can find out itself.
+
+**What you'll be asked.** Nothing; this runs by itself.
+
+**What you get.** A short readout of what was found and what's missing.
+
+**Done when.** You've seen the readout and nothing important is missing.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -79,6 +79,14 @@ Open the project in Claude Code:
    apply, read-back verification, and receipts. The default write mode is
    `propose`; nothing touches your tracker without the configured approval.
 
+Every session opens with a one-line orientation ("engagement at stage X,
+next: …") and a write guard keeps approval and baseline evidence safe from
+accidental edits — both installed automatically. `npx -p github:aithinkers/requirements-dlc rdlc-sensors`
+gives anyone a plain-language health check ("3 stories are missing acceptance
+criteria → /rdlc-draft") — no reading of rule codes required. Team context
+lives in `rdlc/spaces/main/memory/` (organization, project, team) — fill the
+three scaffolded files in and agents will honor them every session.
+
 `/rdlc-status` answers "where was I?" from durable files alone, and
 `/rdlc-doctor` validates installation, policy, and state.
 

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -522,6 +522,33 @@
           "tests/governance/engagement.test.mjs"
         ]
       }
+    },
+    {
+      "id": "FEAT-020",
+      "title": "Human-first runtime — sensors, session hooks, memory, stage guides, upgrade-aware install",
+      "issue": 48,
+      "specification_sections": [
+        "§15",
+        "§34",
+        "§7.2",
+        "§42",
+        "§36"
+      ],
+      "status": "verified",
+      "evidence": {
+        "implementation": [
+          "core/lib/sensors.mjs",
+          "core/hooks/orient.mjs",
+          "core/hooks/guard.mjs",
+          "core/memory/organization.md",
+          "core/stages/bodies/readiness-approval.md",
+          "scripts/run-sensors.mjs",
+          "scripts/setup.mjs"
+        ],
+        "tests": [
+          "tests/governance/human-runtime.test.mjs"
+        ]
+      }
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "ajv": "8.20.0"
   },
   "bin": {
-    "rdlc-setup": "./scripts/setup.mjs"
+    "rdlc-setup": "./scripts/setup.mjs",
+    "rdlc-sensors": "./scripts/run-sensors.mjs"
   },
   "files": [
     "core/",
@@ -58,7 +59,8 @@
     "README.md",
     "SECURITY.md",
     "SUPPORT.md",
-    "LICENSE"
+    "LICENSE",
+    "scripts/run-sensors.mjs"
   ],
   "exports": {
     "./canonical": "./core/lib/canonical.mjs",
@@ -80,6 +82,7 @@
     "./connectors/jira": "./core/connectors/jira/index.mjs",
     "./schemas": "./core/schemas/v0.2/index.mjs",
     "./template-catalog": "./core/lib/template-catalog.mjs",
-    "./connector-config": "./core/lib/connector-config.mjs"
+    "./connector-config": "./core/lib/connector-config.mjs",
+    "./sensors": "./core/lib/sensors.mjs"
   }
 }

--- a/scripts/generate-distribution.mjs
+++ b/scripts/generate-distribution.mjs
@@ -153,14 +153,33 @@ expected.set(
 // installer places it at rdlc/reference/ so command bodies can cite it.
 const protocol = await readFile("core/protocols/stage-protocol.md", "utf8");
 const stagesJson = await readFile("core/stages/stages.json", "utf8");
-const scopeFiles = (await readdir("core/scopes")).sort();
+const scopeFiles = (await readdir("core/scopes")).filter((name) => name.endsWith(".md")).sort();
+const stageGuides = (await readdir("core/stages/bodies")).sort();
+const memoryFiles = (await readdir("core/memory")).sort();
 for (const host of ["claude-code", "codex", "kiro", "kiro-ide"]) {
   expected.set(join(host, "reference", "stage-protocol.md"), protocol);
   expected.set(join(host, "reference", "stages.json"), stagesJson);
   for (const scope of scopeFiles) {
     expected.set(join(host, "reference", "scopes", scope), await readFile(join("core", "scopes", scope), "utf8"));
   }
+  for (const guide of stageGuides) {
+    expected.set(join(host, "reference", "stages", guide), await readFile(join("core", "stages", "bodies", guide), "utf8"));
+  }
+  for (const memory of memoryFiles) {
+    expected.set(join(host, "reference", "memory-templates", memory), await readFile(join("core", "memory", memory), "utf8"));
+  }
 }
+
+// Session hooks ship with the Claude Code surface only (host hook support).
+for (const hook of (await readdir("core/hooks")).sort()) {
+  expected.set(join("claude-code", "hooks", hook), await readFile(join("core", "hooks", hook), "utf8"));
+}
+expected.set(join("claude-code", "hooks", "hooks.json"), JSON.stringify({
+  hooks: {
+    SessionStart: [{ hooks: [{ type: "command", command: "node rdlc/hooks/orient.mjs" }] }],
+    PreToolUse: [{ matcher: "Write|Edit", hooks: [{ type: "command", command: "node rdlc/hooks/guard.mjs" }] }]
+  }
+}, null, 2) + "\n");
 
 // Codex adapter (§36): custom prompts plus md+toml role agents (K-DLC parity).
 expected.set(join("codex", "AGENTS.md"), HOST_OVERVIEW("Codex CLI"));
@@ -207,7 +226,11 @@ const GENERATED_DIRECTORIES = [
   join("claude-code", "commands"), join("claude-code", "agents"), join("claude-code", ".claude-plugin"),
   join("codex", ".codex", "prompts"), join("codex", ".codex", "agents"),
   join("kiro", ".kiro", "agents"), join("kiro-ide", ".kiro", "agents"),
-  ...["claude-code", "codex", "kiro", "kiro-ide"].flatMap((host) => [join(host, "reference"), join(host, "reference", "scopes")])
+  ...["claude-code", "codex", "kiro", "kiro-ide"].flatMap((host) => [
+    join(host, "reference"), join(host, "reference", "scopes"),
+    join(host, "reference", "stages"), join(host, "reference", "memory-templates")
+  ]),
+  join("claude-code", "hooks")
 ];
 
 async function sweepSkills(host, failures) {

--- a/scripts/run-sensors.mjs
+++ b/scripts/run-sensors.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/**
+ * rdlc-sensors — plain-language project health for BAs, POs, and release
+ * managers. Run from any R-DLC project (or --target <dir>). Exit 0 when all
+ * checks pass, 1 when something needs attention.
+ */
+
+import process from "node:process";
+import { resolve } from "node:path";
+
+import { runSensors, SENSORS } from "../core/lib/sensors.mjs";
+
+let target = process.cwd();
+const names = [];
+const argv = process.argv.slice(2);
+for (let index = 0; index < argv.length; index += 1) {
+  if (argv[index] === "--target") target = resolve(argv[++index] ?? ".");
+  else if (argv[index] === "--help" || argv[index] === "-h") {
+    console.log(`Usage: rdlc-sensors [--target <dir>] [check ...]\nChecks: ${Object.keys(SENSORS).join(", ")} (default: all)`);
+    process.exit(0);
+  } else names.push(argv[index]);
+}
+
+const { results, summary, ok } = await runSensors(target, names.length ? { names } : {});
+for (const entry of results) {
+  console.log(`${entry.ok ? "✓" : "✗"} ${entry.headline}${entry.next_command && !entry.ok ? `  → ${entry.next_command}` : ""}`);
+}
+console.log(`\n${summary}`);
+process.exit(ok ? 0 : 1);

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -64,6 +64,10 @@ async function listPluginFiles(tool) {
     for (const relative of await walk(join(base, "reference"))) {
       files.push({ source: join(base, "reference", relative), relative: join("rdlc", "reference", relative) });
     }
+    for (const relative of await walk(join(base, "hooks"))) {
+      if (relative === "hooks.json") continue; // merged into settings below
+      files.push({ source: join(base, "hooks", relative), relative: join("rdlc", "hooks", relative) });
+    }
     return files;
   }
   // Codex and Kiro surfaces install their dot-directory trees verbatim
@@ -192,10 +196,15 @@ const SCAFFOLD_DIRECTORIES = [
   "rdlc/spaces/main/engagements"
 ];
 
-async function fileState(path, expected) {
+async function fileState(path, expected, installedHash) {
   try {
     const current = await readFile(path);
-    return sha256(current) === sha256(expected) ? "unchanged" : "modified";
+    const currentHash = sha256(current);
+    if (currentHash === sha256(expected)) return "unchanged";
+    // Upgrade-aware protection: a file still matching what R-DLC installed
+    // last time was never touched by the user — new versions apply cleanly.
+    if (installedHash && currentHash === installedHash) return "upgradeable";
+    return "modified";
   } catch {
     return "absent";
   }
@@ -211,18 +220,25 @@ export async function runSetup({ target, tool = "claude-code", force = false, ch
   }
   if (!targetStat.isDirectory()) throw new Error(`target is not a directory: ${target}`);
 
+  const manifestPath = join(target, "rdlc", ".install-manifest.json");
+  let installManifest = {};
+  try { installManifest = JSON.parse(await readFile(manifestPath, "utf8")).files ?? {}; } catch { /* first install */ }
   const plan = await listPluginFiles(tool);
   const projectId = basename(resolve(target)) || "rdlc-project";
   plan.push({ content: projectManifest(projectId), relative: "requirements-project.yaml" });
   plan.push({ content: EXAMPLE_MAPPING, relative: join("config", "connectors", "jira-example.yaml") });
   plan.push({ content: ADO_EXAMPLE_MAPPING, relative: join("config", "connectors", "azure-devops-example.yaml") });
 
+  const newManifest = {};
   for (const entry of plan) {
     const destination = join(target, entry.relative);
     const expected = entry.content !== undefined ? Buffer.from(entry.content) : await readFile(entry.source);
-    const state = await fileState(destination, expected);
+    const expectedHash = sha256(expected);
+    const state = await fileState(destination, expected, installManifest[entry.relative]);
+    newManifest[entry.relative] = expectedHash;
     if (check) {
-      if (state !== "unchanged") results.drift.push({ file: entry.relative, state });
+      if (state === "modified") results.drift.push({ file: entry.relative, state });
+      if (state === "absent" || state === "upgradeable") results.drift.push({ file: entry.relative, state });
       continue;
     }
     if (state === "unchanged") {
@@ -230,16 +246,65 @@ export async function runSetup({ target, tool = "claude-code", force = false, ch
       continue;
     }
     if (state === "modified" && !force) {
-      // Never clobber a user-modified file silently.
+      // The user changed this file since we installed it — never clobber.
       results.protected.push(entry.relative);
+      newManifest[entry.relative] = installManifest[entry.relative] ?? expectedHash;
       continue;
     }
     await mkdir(dirname(destination), { recursive: true });
     await writeFile(destination, expected);
-    results.installed.push(entry.relative);
+    (state === "upgradeable" ? (results.upgraded ??= []) : results.installed).push(entry.relative);
+  }
+  if (!check) {
+    await mkdir(dirname(manifestPath), { recursive: true });
+    await writeFile(manifestPath, JSON.stringify({ schema_version: "rdlc.install-manifest/v1", files: newManifest }, null, 2) + "\n");
   }
 
+  if (!check && tool === "claude-code") {
+    // Session hooks: create or merge .claude/settings.json — never touching
+    // hooks that are not ours (issue #48).
+    const settingsPath = join(target, ".claude", "settings.json");
+    let settings = {};
+    let settingsReadable = true;
+    try { settings = JSON.parse(await readFile(settingsPath, "utf8")); } catch (error) {
+      if (error?.code !== "ENOENT") settingsReadable = false;
+    }
+    if (settingsReadable) {
+      const ours = JSON.parse(await readFile(join(packageRoot, "distribution", "claude-code", "hooks", "hooks.json"), "utf8")).hooks;
+      settings.hooks ??= {};
+      let merged = false;
+      for (const [event, entries] of Object.entries(ours)) {
+        settings.hooks[event] ??= [];
+        for (const entry of entries) {
+          const marker = entry.hooks[0].command;
+          if (!JSON.stringify(settings.hooks[event]).includes(marker)) {
+            settings.hooks[event].push(entry);
+            merged = true;
+          }
+        }
+      }
+      if (merged) {
+        await mkdir(dirname(settingsPath), { recursive: true });
+        await writeFile(settingsPath, JSON.stringify(settings, null, 2) + "\n");
+        results.hooks_merged = true;
+      }
+    } else {
+      results.hooks_skipped = "existing .claude/settings.json could not be parsed; hooks not merged";
+    }
+  }
   if (!check) {
+    // Scaffold memory files from templates when absent (user content after that).
+    for (const memory of ["organization.md", "project.md", "team.md"]) {
+      const destination = join(target, "rdlc", "spaces", "main", "memory", memory);
+      try { await stat(destination); } catch {
+        const source = join(packageRoot, "distribution", tool === "claude-code" ? "claude-code" : tool, "reference", "memory-templates", memory);
+        try {
+          await mkdir(dirname(destination), { recursive: true });
+          await writeFile(destination, await readFile(source));
+          results.scaffolded.push(join("rdlc", "spaces", "main", "memory", memory));
+        } catch { /* host without templates */ }
+      }
+    }
     // Migrate away the 0.1.1 layout Claude Code never discovered (issue #34).
     const legacy = join(target, ".claude", "plugins", "rdlc");
     try {
@@ -264,7 +329,9 @@ export async function runSetup({ target, tool = "claude-code", force = false, ch
   if (check) {
     log(results.drift.length === 0 ? "  up to date" : results.drift.map((entry) => `  drift: ${entry.file} (${entry.state})`).join("\n"));
   } else {
-    log(`  installed: ${results.installed.length}, unchanged: ${results.skipped.length}, scaffolded: ${results.scaffolded.length}`);
+    log(`  installed: ${results.installed.length}, upgraded: ${results.upgraded?.length ?? 0}, unchanged: ${results.skipped.length}, scaffolded: ${results.scaffolded.length}`);
+    if (results.hooks_merged) log("  session hooks added to .claude/settings.json (orientation + write guard)");
+    if (results.hooks_skipped) log(`  NOTE: ${results.hooks_skipped}`);
     if (results.migrated) log(`  migrated: removed undiscovered legacy install at ${results.migrated}`);
     for (const file of results.protected) {
       log(`  PROTECTED (user-modified, use --force to overwrite): ${file}`);

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -301,14 +301,14 @@ export async function runSetup({ target, tool = "claude-code", force = false, ch
     // Scaffold memory files from templates when absent (user content after that).
     for (const memory of ["organization.md", "project.md", "team.md"]) {
       const destination = join(target, "rdlc", "spaces", "main", "memory", memory);
-      try { await stat(destination); } catch {
-        const source = join(packageRoot, "distribution", tool === "claude-code" ? "claude-code" : tool, "reference", "memory-templates", memory);
-        try {
-          await mkdir(dirname(destination), { recursive: true });
-          await writeFile(destination, await readFile(source));
-          results.scaffolded.push(join("rdlc", "spaces", "main", "memory", memory));
-        } catch { /* host without templates */ }
-      }
+      const source = join(packageRoot, "distribution", tool === "claude-code" ? "claude-code" : tool, "reference", "memory-templates", memory);
+      try {
+        // Exclusive create: never clobbers user content, no check-then-write race.
+        const content = await readFile(source);
+        await mkdir(dirname(destination), { recursive: true });
+        await writeFile(destination, content, { flag: "wx" });
+        results.scaffolded.push(join("rdlc", "spaces", "main", "memory", memory));
+      } catch { /* already present, or host without templates */ }
     }
     // Migrate away the 0.1.1 layout Claude Code never discovered (issue #34).
     const legacy = join(target, ".claude", "plugins", "rdlc");

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -269,15 +269,20 @@ export async function runSetup({ target, tool = "claude-code", force = false, ch
     try { settings = JSON.parse(await readFile(settingsPath, "utf8")); } catch (error) {
       if (error?.code !== "ENOENT") settingsReadable = false;
     }
-    if (settingsReadable) {
+    const shapeOk = settingsReadable
+      && (settings.hooks === undefined || (typeof settings.hooks === "object" && !Array.isArray(settings.hooks)
+        && Object.values(settings.hooks).every((value) => Array.isArray(value))));
+    if (settingsReadable && shapeOk) {
       const ours = JSON.parse(await readFile(join(packageRoot, "distribution", "claude-code", "hooks", "hooks.json"), "utf8")).hooks;
       settings.hooks ??= {};
       let merged = false;
       for (const [event, entries] of Object.entries(ours)) {
         settings.hooks[event] ??= [];
         for (const entry of entries) {
-          const marker = entry.hooks[0].command;
-          if (!JSON.stringify(settings.hooks[event]).includes(marker)) {
+          const command = entry.hooks[0].command;
+          const present = settings.hooks[event].some((existing) =>
+            (existing.hooks ?? []).some((hook) => hook.command === command));
+          if (!present) {
             settings.hooks[event].push(entry);
             merged = true;
           }
@@ -289,7 +294,7 @@ export async function runSetup({ target, tool = "claude-code", force = false, ch
         results.hooks_merged = true;
       }
     } else {
-      results.hooks_skipped = "existing .claude/settings.json could not be parsed; hooks not merged";
+      results.hooks_skipped = "your .claude/settings.json couldn't be updated automatically (unusual format); to enable the session hooks, copy the entries from rdlc-installed hooks (distribution hooks.json) in yourself — nothing else is affected";
     }
   }
   if (!check) {

--- a/tests/governance/human-runtime.test.mjs
+++ b/tests/governance/human-runtime.test.mjs
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { runSensors } from "../../core/lib/sensors.mjs";
+import { runSetup } from "../../scripts/setup.mjs";
+import { checkpoint, createEngagement } from "../../core/lib/engagement.mjs";
+import { mintIdentity } from "../../core/lib/identity.mjs";
+
+const quiet = () => {};
+const actor = mintIdentity();
+
+async function installedProject() {
+  const target = await mkdtemp(join(tmpdir(), "rdlc-hr-"));
+  await runSetup({ target, log: quiet });
+  return target;
+}
+
+test("FEAT-020: sensors speak human — headlines, next commands, no rule codes at the surface", async () => {
+  const target = await installedProject();
+  const { results, summary, ok } = await runSensors(target);
+  assert.equal(ok, true);
+  for (const entry of results) {
+    assert.ok(entry.headline.length > 15, entry.sensor);
+    assert.ok(!/RDLC-[A-Z]+-\d+/.test(entry.headline), `${entry.sensor} headline has no rule codes`);
+    assert.ok(!/Error:|stack/i.test(entry.headline), entry.sensor);
+  }
+  assert.match(summary, /Everything checks out/);
+
+  // A broken artifact produces a plain-language failure with a next step.
+  const artifactDir = join(target, "rdlc", "spaces", "main", "engagements", "e1", "artifacts", "requirements");
+  await mkdir(artifactDir, { recursive: true });
+  await writeFile(join(artifactDir, "req-1.yaml"), "schema_version: rdlc.artifact/v0.2\nid: not-a-urn\n", "utf8");
+  await writeFile(join(artifactDir, "story-1.yaml"), "type: story\nstatement: incomplete\n", "utf8");
+  const broken = await runSensors(target);
+  assert.equal(broken.ok, false);
+  const schema = broken.results.find((entry) => entry.sensor === "schema");
+  assert.equal(schema.ok, false);
+  assert.match(schema.headline, /can't be read reliably/);
+  assert.equal(schema.next_command, "/rdlc-doctor");
+  const template = broken.results.find((entry) => entry.sensor === "template-catalog");
+  assert.equal(template.ok, false);
+  assert.match(template.headline, /missing expected content/);
+  assert.ok(!/required field missing:/.test(template.headline), "raw failure text stays in details");
+});
+
+test("FEAT-020: the state sensor reports interruption and uncertain writes in plain language", async () => {
+  const target = await installedProject();
+  const directory = join(target, "rdlc", "spaces", "main", "engagements", "e1");
+  await mkdir(directory, { recursive: true });
+  let state = createEngagement({ project: "p", space: "main", scope: "standard", host: "claude-code", session: "s", actor, at: "2026-08-16T10:00:00.000Z" });
+  state = { ...state, uncertain_writes: [{ changeset: "c1", operation_id: "op-1" }] };
+  await checkpoint(state, directory, { at: "2026-08-16T10:00:00.000Z" });
+  const withUncertain = await runSensors(target, { names: ["state"] });
+  assert.match(withUncertain.results[0].headline, /unknown outcome/);
+  assert.equal(withUncertain.results[0].next_command, "/rdlc-sync");
+
+  // Tamper -> interruption message, no stack trace.
+  const statePath = join(directory, "rdlc-state.yaml");
+  await writeFile(statePath, (await readFile(statePath, "utf8")).replace("standard", "tampered"), "utf8");
+  const interrupted = await runSensors(target, { names: ["state"] });
+  assert.equal(interrupted.results[0].ok, false);
+  assert.match(interrupted.results[0].headline, /interrupted mid-save/);
+});
+
+test("FEAT-020: the rdlc-sensors bin prints friendly output and exits by health", async () => {
+  const target = await installedProject();
+  const output = execFileSync("node", ["scripts/run-sensors.mjs", "--target", target], { encoding: "utf8" });
+  assert.match(output, /✓ .*well-formed/);
+  assert.match(output, /Everything checks out/);
+});
+
+test("FEAT-020: the write guard blocks evidence edits with a plain explanation; orient prints the one-liner", async () => {
+  const target = await installedProject();
+  const guard = (path) => {
+    try {
+      execFileSync("node", [join(target, "rdlc", "hooks", "guard.mjs")], { input: JSON.stringify({ tool_input: { file_path: path } }), encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] });
+      return { blocked: false };
+    } catch (error) {
+      return { blocked: true, message: String(error.stderr) };
+    }
+  };
+  const blocked = guard(join(target, "rdlc", "spaces", "main", "engagements", "e1", "approvals", "pkg.yaml"));
+  assert.equal(blocked.blocked, true);
+  assert.match(blocked.message, /audit trail/);
+  assert.match(blocked.message, /\/rdlc-approve/);
+  assert.equal(guard(join(target, "rdlc", "reference", "stage-protocol.md")).blocked, true);
+  assert.equal(guard(join(target, "docs", "notes.md")).blocked, false);
+
+  // Orient: silent outside R-DLC projects, informative inside.
+  const directory = join(target, "rdlc", "spaces", "main", "engagements", "e1");
+  await mkdir(directory, { recursive: true });
+  await checkpoint({ ...createEngagement({ project: "p", space: "main", scope: "quick", host: "claude-code", session: "s", actor, at: "t" }), next_action: "answer the open question" }, directory, { at: "t" });
+  const oriented = execFileSync("node", [join(target, "rdlc", "hooks", "orient.mjs")], { cwd: target, encoding: "utf8" });
+  assert.match(oriented, /quick scope/);
+  assert.match(oriented, /answer the open question/);
+  const outside = execFileSync("node", [join(target, "rdlc", "hooks", "orient.mjs")], { cwd: tmpdir(), encoding: "utf8" });
+  assert.equal(outside.trim(), "");
+});
+
+test("FEAT-020: settings merge adds our hooks once and never disturbs foreign hooks", async () => {
+  const target = await mkdtemp(join(tmpdir(), "rdlc-hooks-"));
+  await mkdir(join(target, ".claude"), { recursive: true });
+  await writeFile(join(target, ".claude", "settings.json"), JSON.stringify({
+    hooks: { PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "my-own-guard.sh" }] }] }
+  }, null, 2), "utf8");
+  await runSetup({ target, log: quiet });
+  const settings = JSON.parse(await readFile(join(target, ".claude", "settings.json"), "utf8"));
+  assert.ok(JSON.stringify(settings).includes("my-own-guard.sh"), "foreign hooks preserved");
+  assert.ok(JSON.stringify(settings).includes("rdlc/hooks/guard.mjs"));
+  assert.ok(JSON.stringify(settings).includes("rdlc/hooks/orient.mjs"));
+  // Idempotent: second run adds nothing.
+  await runSetup({ target, log: quiet });
+  const again = JSON.parse(await readFile(join(target, ".claude", "settings.json"), "utf8"));
+  assert.equal(JSON.stringify(again).split("rdlc/hooks/guard.mjs").length, 2, "exactly one guard entry");
+});
+
+test("FEAT-020: memory templates scaffold once and user edits survive re-runs", async () => {
+  const target = await installedProject();
+  const memory = join(target, "rdlc", "spaces", "main", "memory", "team.md");
+  assert.match(await readFile(memory, "utf8"), /Estimation culture/);
+  await writeFile(memory, "# Team memory\nWe are night owls.\n", "utf8");
+  await runSetup({ target, log: quiet });
+  assert.match(await readFile(memory, "utf8"), /night owls/, "memory is user content after scaffold");
+});
+
+test("FEAT-020: upgrades apply cleanly to untouched files; user edits stay protected (install manifest)", async () => {
+  const target = await installedProject();
+  const manifest = JSON.parse(await readFile(join(target, "rdlc", ".install-manifest.json"), "utf8"));
+  assert.ok(Object.keys(manifest.files).length > 40);
+
+  // Simulate an older install of one file: content differs from the new
+  // version but matches what the manifest says was installed.
+  const protocolPath = join(target, "rdlc", "reference", "stage-protocol.md");
+  const old = "# R-DLC stage protocol (older release)\n";
+  await writeFile(protocolPath, old, "utf8");
+  const { createHash } = await import("node:crypto");
+  manifest.files["rdlc/reference/stage-protocol.md"] = createHash("sha256").update(Buffer.from(old)).digest("hex");
+  await writeFile(join(target, "rdlc", ".install-manifest.json"), JSON.stringify(manifest, null, 2) + "\n", "utf8");
+
+  const upgrade = await runSetup({ target, log: quiet });
+  assert.ok((upgrade.upgraded ?? []).includes(join("rdlc", "reference", "stage-protocol.md")), "untouched old version upgraded without --force");
+  assert.match(await readFile(protocolPath, "utf8"), /R-DLC stage protocol\n/, "new content applied");
+
+  // A genuine user edit is still protected.
+  await writeFile(protocolPath, "my custom protocol", "utf8");
+  const protectedRun = await runSetup({ target, log: quiet });
+  assert.ok(protectedRun.protected.includes(join("rdlc", "reference", "stage-protocol.md")));
+  assert.equal(await readFile(protocolPath, "utf8"), "my custom protocol");
+});
+
+test("FEAT-020: stage guides ship for every ALWAYS stage in plain language", async () => {
+  const target = await installedProject();
+  const graph = JSON.parse(await readFile(join(target, "rdlc", "reference", "stages.json"), "utf8"));
+  for (const stage of graph.stages.filter((entry) => entry.condition === "ALWAYS")) {
+    const guide = await readFile(join(target, "rdlc", "reference", "stages", `${stage.slug}.md`), "utf8");
+    assert.match(guide, /Why this stage exists/, stage.slug);
+    assert.match(guide, /Done when/, stage.slug);
+    assert.ok(!/SHALL|MUST NOT|§\d/.test(guide), `${stage.slug} guide avoids spec legalese`);
+  }
+});

--- a/tests/governance/human-runtime.test.mjs
+++ b/tests/governance/human-runtime.test.mjs
@@ -39,7 +39,7 @@ test("FEAT-020: sensors speak human — headlines, next commands, no rule codes 
   assert.equal(broken.ok, false);
   const schema = broken.results.find((entry) => entry.sensor === "schema");
   assert.equal(schema.ok, false);
-  assert.match(schema.headline, /can't be read reliably/);
+  assert.match(schema.headline, /can't be used reliably/);
   assert.equal(schema.next_command, "/rdlc-doctor");
   const template = broken.results.find((entry) => entry.sensor === "template-catalog");
   assert.equal(template.ok, false);
@@ -161,4 +161,44 @@ test("FEAT-020: stage guides ship for every ALWAYS stage in plain language", asy
     assert.match(guide, /Done when/, stage.slug);
     assert.ok(!/SHALL|MUST NOT|§\d/.test(guide), `${stage.slug} guide avoids spec legalese`);
   }
+});
+
+test("FEAT-020: review fixes — guard normalization, graceful settings shapes, exact-command idempotence, neutral orient", async () => {
+  const target = await installedProject();
+  const guard = (path) => {
+    try {
+      execFileSync("node", [join(target, "rdlc", "hooks", "guard.mjs")], { input: JSON.stringify({ tool_input: { file_path: path } }), stdio: ["pipe", "pipe", "pipe"] });
+      return false;
+    } catch { return true; }
+  };
+  assert.equal(guard("rdlc/./spaces/main/engagements/e1/approvals/a.yaml"), true, "dot-hop blocked");
+  assert.equal(guard("rdlc//spaces//main//engagements//e1//baselines//b.yaml"), true, "double-slash blocked");
+  assert.equal(guard("rdlc\\reference\\stage-protocol.md"), true, "backslash blocked");
+
+  // Wrong-shaped hooks degrade with an actionable note, no crash.
+  const weird = await mkdtemp(join(tmpdir(), "rdlc-weird-"));
+  await mkdir(join(weird, ".claude"), { recursive: true });
+  await writeFile(join(weird, ".claude", "settings.json"), JSON.stringify({ hooks: "oops" }), "utf8");
+  const degraded = await runSetup({ target: weird, log: quiet });
+  assert.match(degraded.hooks_skipped, /couldn't be updated automatically/);
+  assert.equal(JSON.parse(await readFile(join(weird, ".claude", "settings.json"), "utf8")).hooks, "oops", "untouched");
+
+  // A user hook merely MENTIONING our command doesn't suppress the real merge.
+  const mention = await mkdtemp(join(tmpdir(), "rdlc-mention-"));
+  await mkdir(join(mention, ".claude"), { recursive: true });
+  await writeFile(join(mention, ".claude", "settings.json"), JSON.stringify({
+    hooks: { PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "echo node rdlc/hooks/guard.mjs" }] }] }
+  }), "utf8");
+  await runSetup({ target: mention, log: quiet });
+  const merged = JSON.parse(await readFile(join(mention, ".claude", "settings.json"), "utf8"));
+  const commands = merged.hooks.PreToolUse.flatMap((entry) => entry.hooks.map((hook) => hook.command));
+  assert.ok(commands.includes("node rdlc/hooks/guard.mjs"), "real guard installed despite the mention");
+
+  // Orient falls back to a neutral line on garbled state.
+  const directory = join(target, "rdlc", "spaces", "main", "engagements", "weird");
+  await mkdir(directory, { recursive: true });
+  await writeFile(join(directory, "rdlc-state.yaml"), "active_stage: '{{{'\nupdated_at: 2026-08-16T12:00:00Z\n", "utf8");
+  const oriented = execFileSync("node", [join(target, "rdlc", "hooks", "orient.mjs")], { cwd: target, encoding: "utf8" });
+  assert.ok(!oriented.includes("{{{"), "garbage never reaches the session line");
+  assert.ok(!/\bnull\b/.test(oriented), "no literal null");
 });


### PR DESCRIPTION
## Outcome

Completes the aidlc-comparison backlog with a human-first design — every surface speaks BA/PO/release-manager language, and instead of seventeen hooks we ship two backed by the tested engine:

- **Sensors** (`core/lib/sensors.mjs`, `rdlc-sensors` bin): five checks (schema, template content, dependency loops, engagement state, connector config) whose headlines are plain sentences with a suggested command — "3 items are missing expected content … → /rdlc-draft" — rule codes and raw errors demoted to details. Runs against any installed project via npx; exit code reflects health.
- **Two session hooks** (Claude Code): `orient` (SessionStart one-liner: engagement, scope, stage, next action; silent outside R-DLC projects) and `guard` (PreToolUse: blocks direct edits to approvals/baselines/reference with a plain explanation naming the right command). Dependency-free scripts installed to `rdlc/hooks/`; settings merge creates or extends `.claude/settings.json` idempotently and never disturbs foreign hooks.
- **Memory** — three plain-language files scaffolded once in `rdlc/spaces/main/memory/` (organization/project/team) with "how R-DLC uses this" guidance; user content after scaffold, survives re-runs.
- **Stage guides** — fifteen plain-language guides ("why this stage exists / what you'll be asked / what you get / done when", zero spec legalese — test-enforced) installed under `rdlc/reference/stages/` for every ALWAYS stage plus promotion, changeset, apply, and baseline.
- **Upgrade-aware install** — `rdlc/.install-manifest.json` records what was installed; on upgrade, files the user never touched apply cleanly (reported as "upgraded"), and only genuine user edits are protected. Resolves the reviewer's LOW-2 from FEAT-019.

Distribution grows to 293 drift-checked files.

Closes #48

## Traceability

- Requirement IDs: FEAT-020
- Specification sections: §15, §34, §7.2, §42, §36
- Conformance modules affected: Harness:Claude-Code (hooks), all surfaces (reference/memory)
- Traceability index updated: yes — FEAT-020 verified

## Gate evidence

- [x] Feature/requirement definition is complete and linked.
- [x] Implementation plan received the required review (design principle: few engine-backed hooks over many prose hooks; human headlines over rule codes).
- [x] Development stayed within issue scope.
- [x] Deterministic tests cover acceptance and failure criteria.
- [x] Final review considered correctness, security, and traceability.

Commands and results:

```text
npm test — 214 pass, 0 fail (headline hygiene incl. no-rule-code and no-legalese assertions; interruption and uncertain-write messaging; guard block/allow matrix with friendly messages; orient inside/outside projects; settings merge idempotence with foreign-hook preservation; memory scaffold-once; manifest-driven upgrade vs protection; ALWAYS-stage guide coverage)
node scripts/generate-distribution.mjs --check — 293 generated files, byte-exact
```

## Security, privacy, rights, and retention

The guard makes the evidence-integrity rule mechanical at the editor boundary; hooks are dependency-free and fail open for non-R-DLC paths; the settings merge never removes or rewrites anything it didn't add.

## Compatibility, migration, and rollback

First run on an existing install writes the manifest; protection semantics for already-modified files unchanged. Rollback = revert.

## Release and documentation

After merge: tag v0.1.9 and refresh the release.
