### PR TITLE
fix: plugin manifest auto-discovery so install succeeds (#52) [FEAT-022]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
       "name": "rdlc",
       "source": "./distribution/claude-code",
       "description": "Governed R-DLC requirements lifecycle: 26 /rdlc-* commands and 10 role agents.",
-      "version": "0.2.0"
+      "version": "0.2.1"
     }
   ]
 }

--- a/distribution/claude-code/.claude-plugin/plugin.json
+++ b/distribution/claude-code/.claude-plugin/plugin.json
@@ -1,1 +1,1 @@
-{"agents":"./agents","commands":"./commands","description":"Governed R-DLC Claude Code adapter","name":"rdlc","version":"0.2.0"}
+{"description":"Governed R-DLC Claude Code adapter","name":"rdlc","version":"0.2.1"}

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -575,6 +575,26 @@
           "tests/governance/scope-doc.test.mjs"
         ]
       }
+    },
+    {
+      "id": "FEAT-022",
+      "title": "Claude Code plugin manifest uses the auto-discovery form so install succeeds",
+      "issue": 52,
+      "specification_sections": [
+        "36",
+        "47"
+      ],
+      "status": "implemented",
+      "evidence": {
+        "implementation": [
+          "scripts/generate-distribution.mjs",
+          "distribution/claude-code/.claude-plugin/plugin.json",
+          ".claude-plugin/marketplace.json"
+        ],
+        "tests": [
+          "tests/governance/engagement.test.mjs"
+        ]
+      }
     }
   ]
 }

--- a/scripts/generate-distribution.mjs
+++ b/scripts/generate-distribution.mjs
@@ -146,7 +146,7 @@ const expected = new Map(core.commands.map((command) => [join("claude-code", "co
 for (const role of roleCore.roles) expected.set(join("claude-code", "agents", `rdlc-${role.id}.md`), renderAgent(role));
 expected.set(
   join("claude-code", ".claude-plugin", "plugin.json"),
-  JSON.stringify({ agents: "./agents", commands: "./commands", description: "Governed R-DLC Claude Code adapter", name: "rdlc", version: "0.2.0" }) + "\n"
+  JSON.stringify({ description: "Governed R-DLC Claude Code adapter", name: "rdlc", version: "0.2.1" }) + "\n"
 );
 
 // Shared reference tree (stage protocol, stage graph, scope profiles) — the

--- a/tests/governance/engagement.test.mjs
+++ b/tests/governance/engagement.test.mjs
@@ -169,8 +169,11 @@ test("FEAT-012: all ten §38 role lenses generate as agents with the untrusted-c
 test("FEAT-012: the plugin manifest points at generated agents and commands and is drift-protected", async () => {
   const manifest = JSON.parse(await readFile("distribution/claude-code/.claude-plugin/plugin.json", "utf8"));
   assert.equal(manifest.name, "rdlc");
-  assert.equal(manifest.agents, "./agents");
-  assert.equal(manifest.commands, "./commands");
+  // Auto-discovery form: Claude Code rejects explicit agents/commands path
+  // keys and discovers the directories beside the manifest (#52).
+  assert.equal("agents" in manifest, false);
+  assert.equal("commands" in manifest, false);
+  assert.equal(manifest.version, "0.2.1");
   const target = "distribution/claude-code/agents/rdlc-facilitator.md";
   const original = await readFile(target, "utf8");
   try {


### PR DESCRIPTION
Closes #52.

`claude plugin install rdlc@rdlc` failed with `Validation errors: agents: Invalid input`: the generated plugin.json declared explicit `"agents"/"commands"` path keys, which current Claude Code rejects. The manifest now uses the auto-discovery form (name/description/version only; Claude Code discovers `agents/` and `commands/` beside the manifest) — the same fix already proven in knowledge-dlc. Version bumped 0.2.0 → 0.2.1 in both the generator and `.claude-plugin/marketplace.json`, since `claude plugin update` is version-based and blind to content changes. FEAT-012's manifest test updated to assert the auto-discovery contract.

Verified live: after regeneration, `claude plugin install rdlc@rdlc` from the local marketplace succeeds.

## Traceability
- Requirement IDs: FEAT-022
- Specification section(s): sections 36 and 47 (generated Claude Code distribution; plugin manifest and installer surface)

## Verification
Commands and results:
```text
npm test → tests 224, pass 224, fail 0 (includes distribution drift check)
node scripts/verify-governance.mjs → Governance verified: 26 traceable requirements and 5 development gates
claude plugin install rdlc@rdlc → Successfully installed plugin: rdlc@rdlc (previously: Validation errors: agents: Invalid input)
```
