### PR TITLE
fix: npx entry point resolves (#62) [FEAT-027]

### DIFF
--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -671,6 +671,24 @@
         ],
         "tests": []
       }
+    },
+    {
+      "id": "FEAT-027",
+      "title": "npx entry point resolves: name-matching bin and symlink-aware main guard",
+      "issue": 62,
+      "specification_sections": [
+        "47"
+      ],
+      "status": "implemented",
+      "evidence": {
+        "implementation": [
+          "package.json",
+          "scripts/setup.mjs"
+        ],
+        "tests": [
+          "tests/governance/governance.test.mjs"
+        ]
+      }
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "ajv": "8.20.0"
   },
   "bin": {
+    "requirements-dlc": "./scripts/setup.mjs",
     "rdlc-setup": "./scripts/setup.mjs",
     "rdlc-sensors": "./scripts/run-sensors.mjs"
   },

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -14,6 +14,7 @@
  */
 
 import { createHash } from "node:crypto";
+import { realpathSync } from "node:fs";
 import { mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -348,7 +349,10 @@ export async function runSetup({ target, tool = "claude-code", force = false, ch
   return results;
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+// realpathSync both sides: npm/npx install bins as SYMLINKS, and a lexical
+// compare made the npx entry point silently no-op (#62).
+const invokedAs = process.argv[1] ? (() => { try { return realpathSync(resolve(process.argv[1])); } catch { return resolve(process.argv[1]); } })() : null;
+if (invokedAs && invokedAs === realpathSync(fileURLToPath(import.meta.url))) {
   const options = parseArguments(process.argv.slice(2));
   if (options.help) {
     console.log(`Usage: rdlc-setup [--target <dir>] [--tool claude-code|codex|kiro|kiro-ide] [--force] [--check]

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -355,7 +355,7 @@ const invokedAs = process.argv[1] ? (() => { try { return realpathSync(resolve(p
 if (invokedAs && invokedAs === realpathSync(fileURLToPath(import.meta.url))) {
   const options = parseArguments(process.argv.slice(2));
   if (options.help) {
-    console.log(`Usage: rdlc-setup [--target <dir>] [--tool claude-code|codex|kiro|kiro-ide] [--force] [--check]
+    console.log(`Usage: npx github:aithinkers/requirements-dlc (or rdlc-setup) [--target <dir>] [--tool claude-code|codex|kiro|kiro-ide] [--force] [--check]
 
 Exit codes: 0 success/up-to-date; 1 drift found (--check) or setup error;
 2 completed but user-modified files were protected (rerun with --force).`);

--- a/tests/governance/governance.test.mjs
+++ b/tests/governance/governance.test.mjs
@@ -87,3 +87,11 @@ test("FEAT-001: issue body validation requires the three governed sections", () 
   assert.deepEqual(failures, []);
   assert.ok(validateIssueBody({ number: 1, body: "" }, 1).length >= 3);
 });
+
+test("FEAT-027: npx can determine the executable — a bin matches the package name (#62)", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const pkg = JSON.parse(await readFile("package.json", "utf8"));
+  // With multiple bins, npx github:<repo> only works when one bin matches
+  // the package name; this locks the documented zero-install path.
+  assert.equal(pkg.bin[pkg.name], "./scripts/setup.mjs");
+});


### PR DESCRIPTION
Closes #62.

`npx github:aithinkers/requirements-dlc` failed with "could not determine executable to run" (reported live). Two stacked defects:

1. The package declares two bins (`rdlc-setup`, `rdlc-sensors`) and neither matched the package name, so npx could not choose. Fixed with a name-matching `requirements-dlc` bin aliasing the installer; existing bin names unchanged. A regression test locks a name-matching bin entry so future bin additions cannot re-break the documented zero-install path.
2. Once resolvable, the installer's main-module guard compared `argv[1]` lexically against the source file — but npm/npx install bins as symlinks, so under npx the guard silently no-oped with exit 0 (ran, printed nothing, installed nothing). Fixed by realpath-ing both sides (with a fail-open fallback for non-existent paths).

Verified end-to-end: `npx <package> --tool kiro-ide --target .` in a clean directory installs the full surface (86 files including the FEAT-025 hooks/front door, 10 scaffolds) through the symlinked bin.

## Traceability
- Requirement IDs: FEAT-027
- Specification section(s): section 47 (recommended defaults / install surface)

## Verification
Commands and results:
```text
npm test → tests 235, pass 235, fail 0 (new regression: pkg.bin[pkg.name] === "./scripts/setup.mjs")
node scripts/verify-governance.mjs → Governance verified: 31 traceable requirements and 5 gates
Clean-room: npx --yes <package-dir> --tool kiro-ide --target . → installed: 86, scaffolded: 10
  (previously: "could not determine executable"; after fix 1 alone: silent exit-0 no-op)
```
